### PR TITLE
Instructions for running STAC Browser

### DIFF
--- a/stac-browser/README.md
+++ b/stac-browser/README.md
@@ -20,3 +20,7 @@ npm run build -- --CATALOG_URL=${STAC_API_ENDPOINT}
 BROWSER_CODE_BUCKET=s3://delta-dev-stac-browser
 aws s3 cp --recursive dist/ $BROWSER_CODE_BUCKET
 ```
+
+## TODO:
+
+Add CDK Code to automatically deploy. A challenge to doing so is the API handles pagination differently form how the browser code requests. The browser is simply using `?page=2` and our stac-api pages need a next token of the form `token=next:<next-item-id>`.


### PR DESCRIPTION
I wanted to deploy an instance of [STAC Browser](https://github.com/radiantearth/stac-browser) against (one of) our STAC API so we can start to visually explore datasets that have been published. I know at the moment there are multiple STAC APIs at varying stages of development, so the current version of this deployed at http://delta-dev-stac-browser.s3-website-us-east-1.amazonaws.com/ should not be considered authoritative, just a proof of concept.

Goals:
* For internal team use and demo: Visually explore what datasets have been published. Quick way to show stakeholders what datasets we have produced metadata for already and do some quick visualizations of those datasets.
* Longer term vision: Integrate a STAC browser into Jupyter Notebooks so users can take a STAC query and pull it into their notebook environment. I don't _think_ this STAC browser will be the right tool since users will probably want to be able to select after doing a search and filter operation. STAC Browser seems to provide simple listings.

Current known issues with the deployment:

* API - I somewhat arbitrarily selected the most recently deployed STAC API deployment. This does not include all of our published datasets and includes some we haven't published. It would be great if we consolidate around one dev STAC database to use for demo'ing what data has already been published and as it gets published.
* The browser itself doesn't seem to include pagination, so I can only get 10 results at a time.


