### PR TITLE
Add NAT Gateway and private subnets

### DIFF
--- a/network/infrastructure/construct.py
+++ b/network/infrastructure/construct.py
@@ -25,11 +25,7 @@ class VpcConstruct(Construct):
             subnet_type=aws_ec2.SubnetType.PUBLIC,
             cidr_mask=24,
         )
-        isolated_subnet = aws_ec2.SubnetConfiguration(
-            name="isolated",
-            subnet_type=aws_ec2.SubnetType.PRIVATE_ISOLATED,
-            cidr_mask=24,
-        )
+
         private_subnet1 = aws_ec2.SubnetConfiguration(
             name="private-subnet-1",
             subnet_type=aws_ec2.SubnetType.PRIVATE,
@@ -48,7 +44,6 @@ class VpcConstruct(Construct):
             cidr="10.10.0.0/16",
             subnet_configuration=[
                 public_subnet,
-                isolated_subnet,
                 private_subnet1,
                 private_subnet2
             ],


### PR DESCRIPTION
closes #22 

- [x] add private subnets
- [x] add nat gateway

i _believe_ that private subnets will automatically get a route table with a route to the nat gateway

@anayeaye and i just discussed explicitly defining the RDS security group like [so](https://github.com/NASA-IMPACT/hls-sentinel2-downloader-serverless/blob/main/cdk/downloader_stack.py#L51:L73), after which we can add rules in this workflow for lambdas in the same group to be able to access the RDS instance