### PR TITLE
Fix bug in which deploying withoug vpc_id was broken (3 lines)

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,12 +18,14 @@ stage = os.environ["STAGE"].lower()
 app_name = "delta-backend"
 try:
     vpc_id = os.environ["VPC_ID"]
+    existing_vpc = True
     # If deploying to existing VPC, default stack account and region are required
     cdk_env = {
         "account": os.environ["CDK_DEFAULT_ACCOUNT"],
         "region": os.environ["CDK_DEFAULT_REGION"],
     }
 except KeyError:
+    existing_vpc = False
     cdk_env = {}
 
 app = App()
@@ -43,7 +45,7 @@ delta_stack = DeltaStack(
     env=cdk_env,
 )
 
-if vpc_id:
+if existing_vpc:
     vpc = VpcConstruct(delta_stack, "network", vpc_id=vpc_id, stage=stage)
 else:
     vpc = VpcConstruct(delta_stack, "network", stage=stage)


### PR DESCRIPTION
# What
I accidentally induced a condition in app.py in which the variable vpc_id was not defined but was used in a conditional when I was cleaning up some validation errors. This change now succeeds with or without a vpc_id defined in the environment.

# How tested
Confirmed deployment to dev stack without passing a vpc in env and deployed test stack with vpc_id in env.