### PR TITLE
Assume but do not edit role policy

### DIFF
--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -108,19 +108,13 @@ class RasterApiLambdaConstruct(Construct):
                 "data-access-role",
                 delta_raster_settings.data_access_role_arn,
             )
-            # Allow data access role to be assumed by lambda
-            data_access_role.grant_principal.add_to_principal_policy(
-                aws_iam.PolicyStatement(
-                    actions=["sts:AssumeRole"],
-                    effect=aws_iam.Effect.ALLOW,
-                    resources=[delta_raster_function.function_arn],
-                )
-            )
+
             # Allow this lambda to assume the data access role
             data_access_role.grant(
                 delta_raster_function.grant_principal,
                 "sts:AssumeRole",
             )
+
             delta_raster_function.add_environment(
                 "DELTA_RASTER_DATA_ACCESS_ROLE_ARN",
                 delta_raster_settings.data_access_role_arn,


### PR DESCRIPTION
# What
This PR removes a step in the raster API construct in which the CDK updated the role-to-be-assumed's policy with the arn of the raster-api's lambda. 

# Why
We are not able to edit external role trust policies. Instead, when a role is provided for the delta backend it should have a permission policy that allows the stack's AWS account to assume the role with a restrictive condition limiting that permission to the delta-backend stack. I.e.
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::<acct>:root"
            },
            "Action": "sts:AssumeRole",
            "Condition": {
                "ArnLike": {
                    "iam:RoleARN": "arn:aws:iam::<acct>:role/<delta-backend-app-name>-*"
                }
            }
        }
    ]
}
```

# How tested
Dev stack deployed with a role from an external account that explicitly allowed all delta-backend buckets from both the stack account and the external account. Then COGs from each bucket were previewed in the dev stack's raster-api `/cog/viewer` endpoint.