### PR TITLE
Fix update collection summaries UDF

### DIFF
--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -184,7 +184,7 @@ def create_update_default_summaries_function(cursor) -> None:
     UPDATE collections SET "content" = "content" || coll_item_cte.summaries
     FROM coll_item_cte
     WHERE collections.id = coll_item_cte.coll_id;
-    $$ LANGUAGE SQL SET SEARCH_PATH TO dashboard, pgstac, public;
+    $$ LANGUAGE SQL SET SEARCH_PATH TO dashboard, pgstac, public SET SESSION_REPLICATION_ROLE TO replica;
     """
 
     cursor.execute(sql.SQL(update_default_summary_sql))
@@ -196,7 +196,7 @@ def create_update_all_default_summaries_function(cursor) -> None:
     update_all_default_summaries_sql = """
     CREATE OR REPLACE FUNCTION dashboard.update_all_default_summaries() RETURNS VOID AS $$
     SELECT
-        update_default_summaries(id)
+        dashboard.update_default_summaries(id)
     FROM collections
     WHERE collections."content" ?| array['item_assets', 'dashboard:is_periodic'];
     $$ LANGUAGE SQL SET SEARCH_PATH TO dashboard, pgstac, public;


### PR DESCRIPTION
# What
Added `SET SESSION_REPLICATION_ROLE TO replica` to `dashboard.update_default_summaries(_collection_id)` UDF to suppress triggers when function is run.

# Why
The update default summaries function stopped working when we upgraded to pgstac v0.6.6 because it triggered indexing in the updated version of the schema and threw this exception:
```
cannot CREATE INDEX "items" because it is being used by active queries in this session
```

# Important note
This change to the update default summaries function requires admin permissions to `set parameter "session_replication_role"`. <ins>The function can no longer be executed as the delta user.</ins>

# How tested
1. Deployed changes to develop stack
2. Loaded `dashboard:is_periodic=true` collection without existing summaries in develop database and executed update_default_summaries(new_collection) <ins>as RDS admin</ins> and verified results.
3. Edited properties in collection to `dashboard:is_periodic=false` and re-loaded with pypgstac and Methods.upsert. Then executed update_all_default_summaries() <ins>as RDS admin</ins> and verified results (this also shows that the update all summaries function which calls update default summaries is working as expected)