### PR TITLE
Specify default db pool size to 1

### DIFF
--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -50,9 +50,9 @@ class StacApiLambdaConstruct(Construct):
             memory_size=delta_stac_settings.memory,
             timeout=Duration.seconds(delta_stac_settings.timeout),
             environment={
-                "DB_MIN_CONN_SIZE": 0, 
+                "DB_MIN_CONN_SIZE": 0,
                 "DB_MAX_CONN_SIZE": 1,
-                **{k.upper(): v for k, v in delta_stac_settings.env.items()}
+                **{k.upper(): v for k, v in delta_stac_settings.env.items()},
             },
             log_retention=aws_logs.RetentionDays.ONE_WEEK,
         )


### PR DESCRIPTION
This arguably could go in the `deltaSTACSettings` class, however by placing defaults in the construct allows developers to add other configurations without overriding the defaults (unless they explicitly specify `db_min_conn_size` or `db_max_conn_size`)

https://github.com/NASA-IMPACT/delta-backend/blob/0e7eb18c50336fe8ed95d16cb184f87465849c88/stac_api/infrastructure/config.py#L7-L10