### PR TITLE
Cog validate endpoint fix 

### DIFF
--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -80,7 +80,7 @@ def cog_validate(
     strict: bool = Query(False, description="Treat warnings as errors"),
 ):
     """Validate a COG"""
-    return rio_cogeo_info(src_path, strict=strict)
+    return rio_cogeo_info(src_path, strict=strict, config=settings.get_gdal_config())
 
 
 @cog.router.get("/viewer", response_class=HTMLResponse)


### PR DESCRIPTION
The `cog/validate` endpoint was failing with `Access Denied`. The `cog_info` function was missing the AWS session env.