### PR TITLE
upgrade pypgstac to be consistent with veda-data-pipelines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extra_reqs = {
         "pytest",
         "pytest-asyncio",
         "httpx",
-        "pypgstac==0.6.6",
+        "pypgstac==0.6.11",
         "psycopg[binary, pool]",
     ],
 }


### PR DESCRIPTION
Related PR:

https://github.com/NASA-IMPACT/veda-data-pipelines/pull/280

This PR just makes `veda-backend` deps match `veda-data-pipeline` deps for `pypgstac`. 

Read through the `pgstac` CHANGELOG and nothing between versions `0.6.6.` and `0.6.11` stands out as backward incompatible (i mean, it is a patch upgrade). So we should be good with this.

This upgrade is to get around a dependency issue `pypgstac` had using an old and `smart-open` package that poetry had trouble dealing with