### PR TITLE
Fix/Update python version in lambda constructs

### DIFF
--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -46,7 +46,7 @@ class BootstrapPgStac(Construct):
             self,
             "lambda",
             handler="handler.handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_8,
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath("./"),
                 file="database/runtime/Dockerfile",

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -39,7 +39,7 @@ class RasterApiLambdaConstruct(Construct):
         veda_raster_function = aws_lambda.Function(
             self,
             "lambda",
-            runtime=aws_lambda.Runtime.PYTHON_3_8,
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="raster_api/runtime/Dockerfile",

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -40,7 +40,7 @@ class StacApiLambdaConstruct(Construct):
             self,
             "lambda",
             handler="handler.handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_8,
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="stac_api/runtime/Dockerfile",


### PR DESCRIPTION
# What
The python runtime version was not updated for lambda constructs.


# How tested
Deployed from local to dev stack and confirmed that API endpoints are reachable/running as expected