### PR TITLE
Upgrade to pgstac 0.7.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extra_reqs = {
         "pytest",
         "pytest-asyncio",
         "httpx==0.23.3",
-        "pypgstac==0.7.6",
+        "pypgstac==0.7.4",
         "psycopg[binary, pool]",
     ],
 }


### PR DESCRIPTION
Pgstac 0.7.6 migration failed because of known bug https://github.com/stac-utils/pgstac/issues/180. Using version 0.7.4 which is the last stable release. 