### PR TITLE
Do not advertise experimental endpoint

### DIFF
--- a/stac_api/runtime/src/api.py
+++ b/stac_api/runtime/src/api.py
@@ -34,6 +34,7 @@ class VedaStacApi(StacApi):
                 CollectionSearchPost,
                 self.response_class,
             ),
+            include_in_schema=False,
         )
 
     def register_get_search(self):
@@ -55,4 +56,5 @@ class VedaStacApi(StacApi):
                 CollectionSearchGet,
                 self.response_class,
             ),
+            include_in_schema=False,
         )


### PR DESCRIPTION
# What
This PR removes the collection id search endpoint from the open api docs. We are still considering using aggregations instead and don't want to commit to supporting this search pattern long term (yet).