### PR TITLE
Enable API hydrate

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -12,6 +12,7 @@ inst_reqs = [
     "importlib_resources>=1.1.0;python_version<'3.9'",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
+    "pydantic<2",
 ]
 
 extra_reqs = {

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -74,6 +74,7 @@ class _ApiSettings(pydantic.BaseSettings):
                 postgres_user=secret["username"],
                 postgres_pass=secret["password"],
                 postgres_port=secret["port"],
+                use_api_hydrate=True,
             )
         else:
             return Settings()


### PR DESCRIPTION
Related: https://github.com/NASA-IMPACT/veda-data/issues/14
Slack thread: https://developmentseed.slack.com/archives/C045K5LAFA9/p1689322864327379

Items with `datetime: null` were being returned without a `datetime` at all, which doesn't match the STAC specification. Enabling this setting will cause API responses to contain `null` properties where they are present in the original item.

There is a warning in the pgstac [docs](https://stac-utils.github.io/pgstac/pgstac/#runtime-configurations) that the hydration process can be CPU intensive. I couldn't find a noticeable impact in my testing, but we should continue to monitor after we deploy this change. If we do find that performance is negatively affected, we can override this setting by adding `{"conf":{"nohydrate"=true/false}}` to search queries.

`pydantic` is pinned in this PR, as a bug was introduced in version 2.0.3 earlier today. https://github.com/NASA-IMPACT/veda-backend/issues/198