### PR TITLE
Put raster assume role config in lambda construct

### DIFF
--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -131,5 +131,5 @@ class RasterApiLambdaConstruct(Construct):
         if veda_raster_settings.export_assume_role_creds_as_envs:
             veda_raster_function.add_environment(
                 "VEDA_RASTER_EXPORT_ASSUME_ROLE_CREDS_AS_ENVS",
-                veda_raster_settings.export_assume_role_creds_as_envs,
+                str(veda_raster_settings.export_assume_role_creds_as_envs),
             )

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -126,3 +126,10 @@ class RasterApiLambdaConstruct(Construct):
                 "VEDA_RASTER_DATA_ACCESS_ROLE_ARN",
                 veda_raster_settings.data_access_role_arn,
             )
+
+        # Optional configuration to export assume role session into lambda function environment
+        if veda_raster_settings.export_assume_role_creds_as_envs:
+            veda_raster_function.add_environment(
+                "VEDA_RASTER_EXPORT_ASSUME_ROLE_CREDS_AS_ENVS",
+                veda_raster_settings.export_assume_role_creds_as_envs,
+            )


### PR DESCRIPTION
# What
Export session credentials in raster api env setting fix [#194] needs to be put in the lambda function construct to be found at runtime