### PR TITLE
Fix/collection extents and summaries

### DIFF
--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -264,7 +264,7 @@ def create_collection_summaries_functions(cursor) -> None:
         SELECT to_jsonb(
             array[
                 to_char(min(datetime) at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
-                to_char(max(datetime) at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
+                to_char(max(end_datetime) at time zone 'Z', 'YYYY-MM-DD"T"HH24:MI:SS"Z"')
             ])​
         FROM items WHERE collection=$1;
     ;

--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -252,7 +252,7 @@ def create_collection_search_functions(cursor) -> None:
 
 def create_collection_summaries_functions(cursor) -> None:
     """
-    Functions to summarize datetimes and raster statistics for 'default' collections of items with single band COG assets
+    Functions to summarize datetimes and raster statistics for 'default' collections of items
     """
 
     periodic_datetime_summary_sql = """
@@ -287,23 +287,6 @@ def create_collection_summaries_functions(cursor) -> None:
     """
     cursor.execute(sql.SQL(distinct_datetime_summary_sql))
 
-    cog_default_summary_sql = """
-    CREATE OR REPLACE FUNCTION dashboard.cog_default_summary(id text) RETURNS jsonb
-    LANGUAGE sql
-    IMMUTABLE PARALLEL SAFE
-    SET search_path TO 'pgstac', 'public'
-    AS $function$
-        SELECT jsonb_build_object(
-            'min', min((items."content"->'assets'->'cog_default'->'raster:bands'-> 0 ->'statistics'->>'minimum')::float),
-            'max', max((items."content"->'assets'->'cog_default'->'raster:bands'-> 0 ->'statistics'->>'maximum')::float)
-        )
-        FROM items WHERE collection=$1;
-    ;
-    $function$
-    ;
-    """
-    cursor.execute(sql.SQL(cog_default_summary_sql))
-
     update_collection_default_summaries_sql = """
     CREATE OR REPLACE FUNCTION dashboard.update_collection_default_summaries(id text)
     RETURNS void
@@ -319,13 +302,6 @@ def create_collection_summaries_functions(cursor) -> None:
                     WHEN (collections."content"->>'dashboard:is_periodic')::boolean
                     THEN dashboard.periodic_datetime_summary(collections.id)
                     ELSE dashboard.discrete_datetime_summary(collections.id)
-                    END
-                ),
-                'cog_default', (
-                    CASE
-                    WHEN collections."content"->'item_assets' ? 'cog_default'
-                    THEN dashboard.cog_default_summary(collections.id)
-                    ELSE NULL
                     END
                 )
             )
@@ -343,27 +319,9 @@ def create_collection_summaries_functions(cursor) -> None:
     LANGUAGE sql
     SET search_path TO 'pgstac', 'public'
     AS $function$
-    UPDATE collections SET
-        "content" = "content" ||
-        jsonb_build_object(
-            'summaries', jsonb_build_object(
-                'datetime', (
-                    CASE
-                    WHEN (collections."content"->>'dashboard:is_periodic')::boolean
-                    THEN dashboard.periodic_datetime_summary(collections.id)
-                    ELSE dashboard.discrete_datetime_summary(collections.id)
-                    END
-                ),
-                'cog_default', (
-                    CASE
-                    WHEN collections."content"->'item_assets' ? 'cog_default'
-                    THEN dashboard.cog_default_summary(collections.id)
-                    ELSE NULL
-                    END
-                )
-            )
-        )
-        WHERE collections."content" ?| array['item_assets', 'dashboard:is_periodic']
+    SELECT dashboard.update_collection_default_summaries(collections.id)
+    FROM collections
+    WHERE collections."content" ?| array['dashboard:is_periodic']
     ;
     $function$
     ;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   database:
     container_name: veda.db
     platform: linux/amd64
-    image: ghcr.io/stac-utils/pgstac:v0.7.6
+    image: ghcr.io/stac-utils/pgstac:v0.7.10
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password


### PR DESCRIPTION
## What
This is an update to the collection summaries methods for two reasons:
1. In the utility function dashboard.periodic_datetime_summary the datetime extent method was updated to extend to the maximum end_datetime from the collection's items (previously the nominal datetime was used which will not capture the full range of a collection of items that implement start/end datetimes).
2. The cog_default summaries are removed to eliminate confusion--the method was only applicable to a very specific use case in which all items had an asset with the key `cog_default` that referred to a single band cloud optimized geotiff. The cog default summary is not used.
3. The bulk update all collection default summaries method was simplified. This method selects all collections that use the dashboard:is_periodic property and then runs dashboard.update_default_collection_summaries for each.

## Notes
1. Two functions in the dashboard schema are changed but the function signature is not so the update can be applied to existing databases. The `VEDA_DB_SCHEMA_VERSION` must be incremented to cause the database handler to be run.
2. The pgstac version was behind in docker compose so it is updated in this PR.

## How tested
Tested with a temporary stack based on an older snapshot of the staging database. First the extent and datetime object the collection summaries was modified for one collection. Next `pgstac.update_collection_extent(collection_id text)` was tested and the result validated (this is important to know for a downstream ingest step that uses the method. Then the bulk `dashboard.update_all_collection_default_summaries()` method was executed to confirm that the periodic datetime summary utility function is working as well as the shortened bulk update all summaries function works as expected.