### PR TITLE
Include path prefix for raster and stac APIs

### DIFF
--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -73,7 +73,7 @@ class vedaRasterSettings(BaseSettings):
         "",
         description="Optional path prefix to add to all api endpoints",
     )
-    
+
     class Config:
         """model config"""
 

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -69,6 +69,11 @@ class vedaRasterSettings(BaseSettings):
         description="Set optional global parameter to 'requester' if the requester agrees to pay S3 transfer costs",
     )
 
+    path_prefix: Optional[str] = Field(
+        "",
+        description="Optional path prefix to add to all api endpoints",
+    )
+    
     class Config:
         """model config"""
 

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -70,7 +70,7 @@ class vedaRasterSettings(BaseSettings):
     )
 
     path_prefix: Optional[str] = Field(
-        "",
+        None,
         description="Optional path prefix to add to all api endpoints",
     )
 

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -70,7 +70,7 @@ class vedaRasterSettings(BaseSettings):
     )
 
     path_prefix: Optional[str] = Field(
-        None,
+        "",
         description="Optional path prefix to add to all api endpoints",
     )
 

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -69,6 +69,10 @@ class RasterApiLambdaConstruct(Construct):
             "VEDA_RASTER_PGSTAC_SECRET_ARN", database.pgstac.secret.secret_full_arn
         )
 
+        veda_raster_function.add_environment(
+            "VEDA_RASTER_PATH_PREFIX", veda_raster_settings.path_prefix
+        )
+
         # Optional AWS S3 requester pays global setting
         if veda_raster_settings.aws_request_payer:
             veda_raster_function.add_environment(

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -47,11 +47,12 @@ if settings.debug:
 else:
     optional_headers = []
 
+path_prefix = settings.path_prefix
 app = FastAPI(
     title=settings.name,
     version=veda_raster_version,
-    openapi_url=f"{settings.router_prefix()}/openapi.json",
-    docs_url=f"{settings.router_prefix()}/docs",
+    openapi_url=f"{path_prefix}/openapi.json",
+    docs_url=f"{path_prefix}/docs",
 )
 
 # router to be applied to all titiler route factories (improves logs with FastAPI context)
@@ -62,28 +63,28 @@ add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
 # Custom PgSTAC mosaic tiler
 mosaic = MosaicTilerFactory(
-    router_prefix=f"{settings.router_prefix()}/mosaic",
+    router_prefix=f"{path_prefix}/mosaic",
     add_mosaic_list=settings.enable_mosaic_search,
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     dataset_dependency=DatasetParams,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"])
+app.include_router(mosaic.router, prefix=f"{path_prefix}/mosaic", tags=["Mosaic"])
 
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
     reader=PgSTACReader,
     path_dependency=ItemPathParams,
     optional_headers=optional_headers,
-    router_prefix=f"{settings.router_prefix()}/stac",
+    router_prefix=f"{path_prefix}/stac",
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac")
+app.include_router(stac.router, tags=["Items"], prefix=f"{path_prefix}/stac")
 
 cog = TilerFactory(
-    router_prefix=f"{settings.router_prefix()}/cog",
+    router_prefix=f"{path_prefix}/cog",
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -119,7 +120,7 @@ def cog_demo(request: Request):
 
 
 app.include_router(
-    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{settings.router_prefix()}/cog"
+    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{path_prefix}/cog"
 )
 
 

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -69,9 +69,7 @@ mosaic = MosaicTilerFactory(
     dataset_dependency=DatasetParams,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(
-    mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"]
-)
+app.include_router(mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"])
 
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
@@ -82,9 +80,7 @@ stac = MultiBaseTilerFactory(
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(
-    stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac"
-)
+app.include_router(stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac")
 
 cog = TilerFactory(
     router_prefix=f"{settings.router_prefix()}/cog",
@@ -123,9 +119,7 @@ def cog_demo(request: Request):
 
 
 app.include_router(
-    cog.router,
-    tags=["Cloud Optimized GeoTIFF"],
-    prefix=f"{settings.router_prefix()}/cog",
+    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{settings.router_prefix()}/cog"
 )
 
 

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -69,7 +69,9 @@ mosaic = MosaicTilerFactory(
     dataset_dependency=DatasetParams,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"])
+app.include_router(
+    mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"]
+)
 
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
@@ -80,7 +82,9 @@ stac = MultiBaseTilerFactory(
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac")
+app.include_router(
+    stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac"
+)
 
 cog = TilerFactory(
     router_prefix=f"{settings.router_prefix()}/cog",
@@ -119,7 +123,9 @@ def cog_demo(request: Request):
 
 
 app.include_router(
-    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{settings.router_prefix()}/cog"
+    cog.router,
+    tags=["Cloud Optimized GeoTIFF"],
+    prefix=f"{settings.router_prefix()}/cog",
 )
 
 

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -47,7 +47,14 @@ if settings.debug:
 else:
     optional_headers = []
 
-app = FastAPI(title=settings.name, version=veda_raster_version)
+path_prefix = settings.path_prefix
+app = FastAPI(
+    title=settings.name,
+    version=veda_raster_version,
+    openapi_url=f"{path_prefix}/openapi.json",
+    docs_url=f"{path_prefix}/docs",
+)
+
 # router to be applied to all titiler route factories (improves logs with FastAPI context)
 router = APIRouter(route_class=LoggerRouteHandler)
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
@@ -56,28 +63,28 @@ add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
 # Custom PgSTAC mosaic tiler
 mosaic = MosaicTilerFactory(
-    router_prefix="/mosaic",
+    router_prefix=f"{path_prefix}/mosaic",
     add_mosaic_list=settings.enable_mosaic_search,
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     dataset_dependency=DatasetParams,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(mosaic.router, prefix="/mosaic", tags=["Mosaic"])
+app.include_router(mosaic.router, prefix=f"{path_prefix}/mosaic", tags=["Mosaic"])
 
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
     reader=PgSTACReader,
     path_dependency=ItemPathParams,
     optional_headers=optional_headers,
-    router_prefix="/stac",
+    router_prefix=f"{path_prefix}/stac",
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(stac.router, tags=["Items"], prefix="/stac")
+app.include_router(stac.router, tags=["Items"], prefix=f"{path_prefix}/stac")
 
 cog = TilerFactory(
-    router_prefix="/cog",
+    router_prefix=f"{path_prefix}/cog",
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -112,7 +119,9 @@ def cog_demo(request: Request):
     )
 
 
-app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
+app.include_router(
+    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{path_prefix}/cog"
+)
 
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -47,12 +47,11 @@ if settings.debug:
 else:
     optional_headers = []
 
-path_prefix = settings.path_prefix
 app = FastAPI(
     title=settings.name,
     version=veda_raster_version,
-    openapi_url=f"{path_prefix}/openapi.json",
-    docs_url=f"{path_prefix}/docs",
+    openapi_url=f"{settings.router_prefix()}/openapi.json",
+    docs_url=f"{settings.router_prefix()}/docs",
 )
 
 # router to be applied to all titiler route factories (improves logs with FastAPI context)
@@ -63,28 +62,28 @@ add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
 # Custom PgSTAC mosaic tiler
 mosaic = MosaicTilerFactory(
-    router_prefix=f"{path_prefix}/mosaic",
+    router_prefix=f"{settings.router_prefix()}/mosaic",
     add_mosaic_list=settings.enable_mosaic_search,
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     dataset_dependency=DatasetParams,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(mosaic.router, prefix=f"{path_prefix}/mosaic", tags=["Mosaic"])
+app.include_router(mosaic.router, prefix=f"{settings.router_prefix()}/mosaic", tags=["Mosaic"])
 
 # Custom STAC titiler endpoint (not added to the openapi docs)
 stac = MultiBaseTilerFactory(
     reader=PgSTACReader,
     path_dependency=ItemPathParams,
     optional_headers=optional_headers,
-    router_prefix=f"{path_prefix}/stac",
+    router_prefix=f"{settings.router_prefix()}/stac",
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
 )
-app.include_router(stac.router, tags=["Items"], prefix=f"{path_prefix}/stac")
+app.include_router(stac.router, tags=["Items"], prefix=f"{settings.router_prefix()}/stac")
 
 cog = TilerFactory(
-    router_prefix=f"{path_prefix}/cog",
+    router_prefix=f"{settings.router_prefix()}/cog",
     optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -120,7 +119,7 @@ def cog_demo(request: Request):
 
 
 app.include_router(
-    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{path_prefix}/cog"
+    cog.router, tags=["Cloud Optimized GeoTIFF"], prefix=f"{settings.router_prefix()}/cog"
 )
 
 

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -53,7 +53,10 @@ class ApiSettings(BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
-    path_prefix: str = ""
+    path_prefix: Optional[str] = Field(
+        None,
+        description="Optional path prefix to add to raster api endpoint",
+    )
 
     # MosaicTiler settings
     enable_mosaic_search: bool = False
@@ -132,6 +135,12 @@ class ApiSettings(BaseSettings):
             # Use the default role of this lambda
             return {}
 
+    def router_prefix(self):
+        if self.path_prefix:
+            return self.path_prefix
+        else:
+            return ""
+    
     class Config:
         """model config"""
 

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -136,12 +136,11 @@ class ApiSettings(BaseSettings):
             return {}
 
     def router_prefix(self):
-        """Conditional to set path prefix"""
         if self.path_prefix:
             return self.path_prefix
         else:
             return ""
-
+    
     class Config:
         """model config"""
 

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -53,6 +53,7 @@ class ApiSettings(BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
+    path_prefix: str = ""
 
     # MosaicTiler settings
     enable_mosaic_search: bool = False

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -136,11 +136,12 @@ class ApiSettings(BaseSettings):
             return {}
 
     def router_prefix(self):
+        """Conditional to set path prefix"""
         if self.path_prefix:
             return self.path_prefix
         else:
             return ""
-    
+
     class Config:
         """model config"""
 

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -53,10 +53,7 @@ class ApiSettings(BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
-    path_prefix: Optional[str] = Field(
-        None,
-        description="Optional path prefix to add to raster api endpoint",
-    )
+    path_prefix: str = ""
 
     # MosaicTiler settings
     enable_mosaic_search: bool = False
@@ -135,12 +132,6 @@ class ApiSettings(BaseSettings):
             # Use the default role of this lambda
             return {}
 
-    def router_prefix(self):
-        if self.path_prefix:
-            return self.path_prefix
-        else:
-            return ""
-    
     class Config:
         """model config"""
 

--- a/stac_api/infrastructure/config.py
+++ b/stac_api/infrastructure/config.py
@@ -18,6 +18,11 @@ class vedaSTACSettings(BaseSettings):
         description="Name or ARN of the AWS Secret containing database connection parameters",
     )
 
+    path_prefix: Optional[str] = Field(
+        "",
+        description="Optional path prefix to add to all api endpoints",
+    )
+
     class Config:
         """model config"""
 

--- a/stac_api/infrastructure/config.py
+++ b/stac_api/infrastructure/config.py
@@ -19,7 +19,7 @@ class vedaSTACSettings(BaseSettings):
     )
 
     path_prefix: Optional[str] = Field(
-        None,
+        "",
         description="Optional path prefix to add to all api endpoints",
     )
 

--- a/stac_api/infrastructure/config.py
+++ b/stac_api/infrastructure/config.py
@@ -19,7 +19,7 @@ class vedaSTACSettings(BaseSettings):
     )
 
     path_prefix: Optional[str] = Field(
-        "",
+        None,
         description="Optional path prefix to add to all api endpoints",
     )
 

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -70,6 +70,10 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_PGSTAC_SECRET_ARN", database.pgstac.secret.secret_full_arn
         )
 
+        lambda_function.add_environment(
+            "VEDA_STAC_PATH_PREFIX", veda_stac_settings.path_prefix
+        )
+
         stac_api_integration = (
             aws_apigatewayv2_integrations_alpha.HttpLambdaIntegration(
                 construct_id, handler=lambda_function

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -32,13 +32,13 @@ templates = Jinja2Templates(directory=str(resources_files(__package__) / "templa
 
 api_settings = ApiSettings()
 tiles_settings = TilesApiSettings()
-path_prefix = api_settings.path_prefix
+
 
 api = VedaStacApi(
     app=FastAPI(
         title=api_settings.name,
-        openapi_url=f"{path_prefix}/openapi.json",
-        docs_url=f"{path_prefix}/docs",
+        openapi_url=f"{api_settings.router_prefix()}/openapi.json",
+        docs_url=f"{api_settings.router_prefix()}/docs",
     ),
     title=api_settings.name,
     description=api_settings.name,
@@ -49,7 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
-    router=APIRouter(prefix=f"{path_prefix}"),
+    router=APIRouter(prefix=f"{api_settings.router_prefix()}"),
 )
 app = api.app
 

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -49,7 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
-    router=APIRouter(prefix=f"{path_prefix}")
+    router=APIRouter(prefix=f"{path_prefix}"),
 )
 app = api.app
 

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -8,7 +8,7 @@ from src.config import get_request_model as GETModel
 from src.config import post_request_model as POSTModel
 from src.extension import TiTilerExtension
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 from starlette.middleware.cors import CORSMiddleware
@@ -32,9 +32,14 @@ templates = Jinja2Templates(directory=str(resources_files(__package__) / "templa
 
 api_settings = ApiSettings()
 tiles_settings = TilesApiSettings()
+path_prefix = api_settings.path_prefix
 
 api = VedaStacApi(
-    app=FastAPI(title=api_settings.name),
+    app=FastAPI(
+        title=api_settings.name,
+        openapi_url=f"{path_prefix}/openapi.json",
+        docs_url=f"{path_prefix}/docs",
+    ),
     title=api_settings.name,
     description=api_settings.name,
     settings=api_settings.load_postgres_settings(),
@@ -44,6 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
+    router=APIRouter(prefix=f"{path_prefix}")
 )
 app = api.app
 

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -32,13 +32,13 @@ templates = Jinja2Templates(directory=str(resources_files(__package__) / "templa
 
 api_settings = ApiSettings()
 tiles_settings = TilesApiSettings()
-
+path_prefix = api_settings.path_prefix
 
 api = VedaStacApi(
     app=FastAPI(
         title=api_settings.name,
-        openapi_url=f"{api_settings.router_prefix()}/openapi.json",
-        docs_url=f"{api_settings.router_prefix()}/docs",
+        openapi_url=f"{path_prefix}/openapi.json",
+        docs_url=f"{path_prefix}/docs",
     ),
     title=api_settings.name,
     description=api_settings.name,
@@ -49,7 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
-    router=APIRouter(prefix=f"{api_settings.router_prefix()}"),
+    router=APIRouter(prefix=f"{path_prefix}"),
 )
 app = api.app
 

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -53,12 +53,7 @@ class _ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
-
-    path_prefix: Optional[str] = pydantic.Field(
-        None,
-        description="Optional path prefix to add to stac api endpoint",
-    )
-
+    path_prefix: str = ""
     pgstac_secret_arn: Optional[str]
 
     @pydantic.validator("cors_origins")
@@ -82,12 +77,6 @@ class _ApiSettings(pydantic.BaseSettings):
             )
         else:
             return Settings()
-
-    def router_prefix(self):
-        if self.path_prefix:
-            return self.path_prefix
-        else:
-            return ""
 
     class Config:
         """model config"""

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -53,7 +53,7 @@ class _ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
-
+    path_prefix: str = ""
     pgstac_secret_arn: Optional[str]
 
     @pydantic.validator("cors_origins")

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -84,7 +84,6 @@ class _ApiSettings(pydantic.BaseSettings):
             return Settings()
 
     def router_prefix(self):
-        """Conditional to set path prefix"""
         if self.path_prefix:
             return self.path_prefix
         else:

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -53,7 +53,12 @@ class _ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
-    path_prefix: str = ""
+
+    path_prefix: Optional[str] = pydantic.Field(
+        None,
+        description="Optional path prefix to add to stac api endpoint",
+    )
+
     pgstac_secret_arn: Optional[str]
 
     @pydantic.validator("cors_origins")
@@ -77,6 +82,12 @@ class _ApiSettings(pydantic.BaseSettings):
             )
         else:
             return Settings()
+
+    def router_prefix(self):
+        if self.path_prefix:
+            return self.path_prefix
+        else:
+            return ""
 
     class Config:
         """model config"""

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -84,6 +84,7 @@ class _ApiSettings(pydantic.BaseSettings):
             return Settings()
 
     def router_prefix(self):
+        """Conditional to set path prefix"""
         if self.path_prefix:
             return self.path_prefix
         else:

--- a/stac_api/runtime/src/extension.py
+++ b/stac_api/runtime/src/extension.py
@@ -4,6 +4,7 @@ from typing import Optional
 from urllib.parse import urlencode
 
 import attr
+from src.config import ApiSettings
 
 from fastapi import APIRouter, FastAPI, HTTPException, Path, Query
 from fastapi.responses import RedirectResponse
@@ -12,7 +13,8 @@ from starlette.requests import Request
 
 from .monitoring import LoggerRouteHandler, tracer
 
-router = APIRouter(route_class=LoggerRouteHandler)
+api_settings = ApiSettings()
+path_prefix = api_settings.path_prefix
 
 MAX_B64_ITEM_SIZE = 2000
 
@@ -29,7 +31,7 @@ class TiTilerExtension(ApiExtension):
             None
 
         """
-        router = APIRouter(route_class=LoggerRouteHandler)
+        router = APIRouter(route_class=LoggerRouteHandler, prefix=path_prefix)
 
         @tracer.capture_method
         @router.get(


### PR DESCRIPTION
Include path prefix for raster and stac APIs.

Related to Issue https://github.com/NASA-IMPACT/veda-backend/issues/208

NOTE: Before merging add the following to the secrets manager for backend `dev`:
```
VEDA_RASTER_PATH_PREFIX=/api/raster
VEDA_STAC_PATH_PREFIX=/api/stac
```