### PR TITLE
fix: include stage subdomain in cloudfront distribution

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ domain = DomainConstruct(veda_stack, "domain", stage=veda_app_settings.stage_nam
 raster_api = RasterApiLambdaConstruct(
     veda_stack,
     "raster-api",
+    stage=veda_app_settings.stage_name(),
     vpc=vpc.vpc,
     database=database,
     domain_name=domain.raster_domain_name,
@@ -66,6 +67,7 @@ raster_api = RasterApiLambdaConstruct(
 stac_api = StacApiLambdaConstruct(
     veda_stack,
     "stac-api",
+    stage=veda_app_settings.stage_name(),
     vpc=vpc.vpc,
     database=database,
     raster_api=raster_api,
@@ -75,6 +77,7 @@ stac_api = StacApiLambdaConstruct(
 veda_routes = CloudfrontDistributionConstruct(
     veda_stack,
     "routes",
+    stage=veda_app_settings.stage_name(),
     raster_api_id=raster_api.raster_api.api_id,
     stac_api_id=stac_api.stac_api.api_id,
     region=veda_app_settings.cdk_default_region,

--- a/app.py
+++ b/app.py
@@ -95,6 +95,7 @@ if veda_app_settings.alt_domain():
     alt_raster_api = RasterApiLambdaConstruct(
         veda_stack,
         "alt-raster-api",
+        stage=veda_app_settings.stage_name(),
         vpc=vpc.vpc,
         database=database,
         domain_name=alt_domain.raster_domain_name,
@@ -103,6 +104,7 @@ if veda_app_settings.alt_domain():
     alt_stac_api = StacApiLambdaConstruct(
         veda_stack,
         "alt-stac-api",
+        stage=veda_app_settings.stage_name(),
         vpc=vpc.vpc,
         database=database,
         raster_api=raster_api,

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -24,6 +24,7 @@ class RasterApiLambdaConstruct(Construct):
         self,
         scope: Construct,
         construct_id: str,
+        stage: str,
         vpc,
         database,
         code_dir: str = "./",
@@ -89,7 +90,7 @@ class RasterApiLambdaConstruct(Construct):
             ] = aws_apigatewayv2_alpha.ParameterMapping().overwrite_header(
                 "host",
                 aws_apigatewayv2_alpha.MappingValue(
-                    veda_raster_settings.domain_hosted_zone_name
+                    f"{stage}.{veda_raster_settings.domain_hosted_zone_name}"
                 ),
             )
 

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -8,7 +8,6 @@ from aws_cdk import aws_cloudfront as cf
 from aws_cdk import aws_cloudfront_origins as origins
 from aws_cdk import aws_route53, aws_route53_targets
 from aws_cdk import aws_s3 as s3
-
 from constructs import Construct
 
 from .config import veda_route_settings

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -6,7 +6,9 @@ from aws_cdk import CfnOutput, Stack
 from aws_cdk import aws_certificatemanager as certificatemanager
 from aws_cdk import aws_cloudfront as cf
 from aws_cdk import aws_cloudfront_origins as origins
+from aws_cdk import aws_route53, aws_route53_targets
 from aws_cdk import aws_s3 as s3
+
 from constructs import Construct
 
 from .config import veda_route_settings
@@ -19,6 +21,7 @@ class CloudfrontDistributionConstruct(Construct):
         self,
         scope: Construct,
         construct_id: str,
+        stage: str,
         raster_api_id: str,
         stac_api_id: str,
         region: Optional[str],
@@ -53,36 +56,57 @@ class CloudfrontDistributionConstruct(Construct):
                     origin=origins.HttpOrigin(
                         s3Bucket.bucket_website_domain_name,
                         protocol_policy=cf.OriginProtocolPolicy.HTTP_ONLY,
+                        origin_id="stac-browser",
                     ),
                     cache_policy=cf.CachePolicy.CACHING_DISABLED,
                 ),
                 certificate=domain_cert,
-                domain_names=[veda_route_settings.domain_hosted_zone_name]
+                domain_names=[f"{stage}.{veda_route_settings.domain_hosted_zone_name}"]
                 if veda_route_settings.domain_hosted_zone_name
                 else None,
                 additional_behaviors={
                     "/api/stac*": cf.BehaviorOptions(
                         origin=origins.HttpOrigin(
-                            f"{stac_api_id}.execute-api.{region}.amazonaws.com"
+                            f"{stac_api_id}.execute-api.{region}.amazonaws.com",
+                            origin_id="stac-api",
                         ),
                         cache_policy=cf.CachePolicy.CACHING_DISABLED,
                         allowed_methods=cf.AllowedMethods.ALLOW_ALL,
                     ),
                     "/api/raster*": cf.BehaviorOptions(
                         origin=origins.HttpOrigin(
-                            f"{raster_api_id}.execute-api.{region}.amazonaws.com"
+                            f"{raster_api_id}.execute-api.{region}.amazonaws.com",
+                            origin_id="raster-api",
                         ),
                         cache_policy=cf.CachePolicy.CACHING_DISABLED,
                         allowed_methods=cf.AllowedMethods.ALLOW_ALL,
                     ),
                     "/api/ingest*": cf.BehaviorOptions(
                         origin=origins.HttpOrigin(
-                            urlparse(veda_route_settings.ingest_url).hostname
+                            urlparse(veda_route_settings.ingest_url).hostname,
+                            origin_id="ingest-api",
                         ),
                         cache_policy=cf.CachePolicy.CACHING_DISABLED,
                         allowed_methods=cf.AllowedMethods.ALLOW_ALL,
                     ),
                 },
+            )
+
+            hosted_zone = aws_route53.HostedZone.from_hosted_zone_attributes(
+                self,
+                "hosted-zone",
+                hosted_zone_id=veda_route_settings.domain_hosted_zone_id,
+                zone_name=veda_route_settings.domain_hosted_zone_name,
+            )
+
+            aws_route53.ARecord(
+                self,
+                "cloudfront-dns-record",
+                zone=hosted_zone,
+                target=aws_route53.RecordTarget.from_alias(
+                    aws_route53_targets.CloudFrontTarget(self.distribution)
+                ),
+                record_name=stage,
             )
 
             CfnOutput(self, "Endpoint", value=self.distribution.domain_name)

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -23,6 +23,7 @@ class StacApiLambdaConstruct(Construct):
         self,
         scope: Construct,
         construct_id: str,
+        stage: str,
         vpc,
         database,
         raster_api,  # TODO: typing!
@@ -81,7 +82,7 @@ class StacApiLambdaConstruct(Construct):
             ] = aws_apigatewayv2_alpha.ParameterMapping().overwrite_header(
                 "host",
                 aws_apigatewayv2_alpha.MappingValue(
-                    veda_stac_settings.domain_hosted_zone_name
+                    f"{stage}.{veda_stac_settings.domain_hosted_zone_name}"
                 ),
             )
 


### PR DESCRIPTION
The cloudfront distribution includes the `stage` env as the subdomain:

`{stage}.{domain_hosted_zone_name}.com`