### PR TITLE
update titiler and titiler-pgstac requirement

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -7,10 +7,10 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
-    "titiler.pgstac==0.8.0",
-    "titiler.core>=0.15.1,<0.16",
-    "titiler.mosaic>=0.15.1,<0.16",
-    "titiler.extensions[cogeo]>=0.15.1,<0.16",
+    "titiler.pgstac==0.8.1",
+    "titiler.core>=0.15.5,<0.16",
+    "titiler.mosaic>=0.15.5,<0.16",
+    "titiler.extensions[cogeo]>=0.15.5,<0.16",
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",


### PR DESCRIPTION
This PR does:
- update both titiler and titiler-pgstac to their latest version 

This makes sure options like **dst_crs** in `/statistics` and /feature` (introduces in 0.15.3) is available 

In titiler 0.15.5 and titiler-pgstac 0.8.1 we also added the possibility to apply custom algorithm on `/statistics` methods (ref https://github.com/NASA-IMPACT/veda-config-ghg/issues/209#issuecomment-1804844996)