### PR TITLE
fix(raster): pin rio-tiler 6.2.3.post1

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -14,7 +14,7 @@ inst_reqs = [
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
-    "rio-tiler==6.2.3",
+    "rio-tiler==6.2.3.post1",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
Post release 6.2.3.post1 to get features/fixed which were added after 6.2.3 (fix for weighted spatial average)