### PR TITLE
fix(ci): upgrade github actions to resolve warnings

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -78,12 +78,12 @@ jobs:
           python-version: '3.9'
       
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: 
           node-version: 17
       
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -113,7 +113,7 @@ jobs:
       - name: Deploy 
         run: |
           echo $STAGE
-          cdk deploy --require-approval never
+          cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json
 
   pre-release:
     needs: [deploy]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,12 +78,12 @@ jobs:
           python-version: '3.9'
       
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with: 
           node-version: 17
       
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -113,7 +113,7 @@ jobs:
       - name: Deploy 
         run: |
           echo $STAGE
-          cdk deploy --require-approval never
+          cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json
 
   release:
     needs: [deploy]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,7 @@ jobs:
   lint-conventional-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: CondeNast/conventional-pull-request-action@v0.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -87,12 +87,12 @@ jobs:
           python-version: '3.9'
       
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 17
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -129,4 +129,4 @@ jobs:
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE
-          cdk diff
+          cdk diff >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -129,4 +129,4 @@ jobs:
       - name: Pre deployment CDK diff
         run: |
           echo $STAGE
-          cdk diff >> $GITHUB_OUTPUT
+          cdk diff --outputs-file ${HOME}/cdk-outputs.json


### PR DESCRIPTION
- Upgrade to github actions to resolve outdated node version warnings
- Add cdk deploy output to file to resolve set-output warning
- Conventional PR linter if not not updated: we may need to remove or replace if this [upgrade PR](https://github.com/CondeNast/conventional-pull-request-action/pull/19) is not accepted. For now, there is a warning in the pr action about forcing linter to run on an upgraded node version.

Parent issue https://github.com/NASA-IMPACT/veda-architecture/issues/345