### PR TITLE
feat(ingest): move ingest API into veda-backend

### DIFF
--- a/.github/workflows/data/noaa-emergency-response.json
+++ b/.github/workflows/data/noaa-emergency-response.json
@@ -1,1 +1,28 @@
-{"id":"noaa-emergency-response", "title": "NOAA Emergency Response Imagery", "description":"NOAA Emergency Response Imagery hosted on AWS Public Dataset.","stac_version":"1.0.0","license":"public-domain","links":[],"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2005-01-01T00:00:00Z","null"]]}}}
+{
+    "id": "noaa-emergency-response",
+    "title": "NOAA Emergency Response Imagery",
+    "description": "NOAA Emergency Response Imagery hosted on AWS Public Dataset.",
+    "stac_version": "1.0.0",
+    "license": "public-domain",
+    "links": [],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    -90,
+                    180,
+                    90
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2005-01-01T00:00:00Z",
+                    "null"
+                ]
+            ]
+        }
+    }
+}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -6,7 +6,7 @@ on:
     - develop
 
 jobs:
-  lint:
+  lint-dev:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,8 +28,8 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
     
-  test:
-    needs: [lint]
+  test-dev:
+    needs: [lint-dev]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -61,12 +61,18 @@ jobs:
   
       - name: Integrations tests
         run: python -m pytest .github/workflows/tests/ -vv -s
+      
+      - name: Install reqs for unit tests
+        run: python -m pip install -r ingest_api/requirements.txt
+      
+      - name: Ingest unit tests
+        run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/tests/ -vv -s
 
       - name: Stop services
         run: docker compose stop
 
-  deploy: 
-    needs: [test]
+  deploy-dev: 
+    needs: [test-dev]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: Pull Request - Lint and Test Workflow
 on: [pull_request]
 
 jobs:
-  lint-pr:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -82,7 +82,7 @@ jobs:
         run: docker compose stop
 
   predeploy:
-    needs: [test-pr]
+    needs: [test]
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Launch services
         run: |
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
-          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} \
+          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}}
           docker compose up --build -d
 
       - name: Set up Python

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: Pull Request - Lint and Test Workflow
 on: [pull_request]
 
 jobs:
-  lint:
+  lint-pr:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,6 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Launch services
+        run: |
+          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
+          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} \
+          docker compose up --build -d
+
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -75,7 +82,7 @@ jobs:
         run: docker compose stop
 
   predeploy:
-    needs: [test]
+    needs: [test-pr]
 
     runs-on: ubuntu-latest
     steps:

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@
 import json
 import subprocess
 
-from aws_cdk import App, Stack, Tags, aws_iam
+from aws_cdk import App, Aspects, Stack, Tags, aws_iam
 from aws_cdk import aws_secretsmanager as secretsmanager
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct

--- a/app.py
+++ b/app.py
@@ -13,8 +13,8 @@ from config import veda_app_settings
 from database.infrastructure.construct import RdsConstruct
 from domain.infrastructure.construct import DomainConstruct
 from ingest_api.infrastructure.config import IngestorConfig as ingest_config
-from ingest_api.infrastructure.constructs import ApiConstruct as ingest_api_construct
-from ingest_api.infrastructure.constructs import IngestorConstruct as ingestor_construct
+from ingest_api.infrastructure.construct import ApiConstruct as ingest_api_construct
+from ingest_api.infrastructure.construct import IngestorConstruct as ingestor_construct
 from network.infrastructure.construct import VpcConstruct
 from permissions_boundary.infrastructure.construct import PermissionsBoundaryAspect
 from raster_api.infrastructure.construct import RasterApiLambdaConstruct
@@ -213,6 +213,7 @@ ingest_api = ingest_api_construct(
     config=ingestor_config,
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
+    domain=domain,
 )
 
 ingestor = ingestor_construct(
@@ -223,6 +224,13 @@ ingestor = ingestor_construct(
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
 )
+
+veda_routes.add_ingest_behavior(
+    ingest_api=ingest_api.api, stage=veda_app_settings.stage_name()
+)
+
+# Must be done after all CF behaviors exist
+veda_routes.create_route_records(stage=veda_app_settings.stage_name())
 
 
 def register_ssm_parameter(

--- a/app.py
+++ b/app.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
 """ CDK Configuration for the veda-backend stack."""
 
-from aws_cdk import App, Aspects, Stack, Tags, aws_iam
+import json
+import subprocess
+
+from aws_cdk import App, Stack, Tags, aws_iam
+from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 from config import veda_app_settings
 from database.infrastructure.construct import RdsConstruct
 from domain.infrastructure.construct import DomainConstruct
+from ingest_api.infrastructure.config import IngestorConfig as ingest_config
+from ingest_api.infrastructure.constructs import ApiConstruct as ingest_api_construct
+from ingest_api.infrastructure.constructs import IngestorConstruct as ingestor_construct
 from network.infrastructure.construct import VpcConstruct
 from permissions_boundary.infrastructure.construct import PermissionsBoundaryAspect
 from raster_api.infrastructure.construct import RasterApiLambdaConstruct
@@ -40,6 +48,69 @@ class VedaStack(Stack):
             )
             aws_iam.PermissionsBoundary.of(self).apply(permissions_boundary_policy)
             Aspects.of(self).add(PermissionsBoundaryAspect(permissions_boundary_policy))
+
+    # Core infrastructure, including secrets, OIDC (if enabled)
+
+    def build_oidc(
+        self, oidc_provider_arn: str, oidc_repo_id: str, secret_arn: str, stage: str
+    ):
+        """Create OIDC role and policy"""
+
+        # Locate an IAM OIDC provider for the specified provider ARN
+        oidc_provider = aws_iam.OpenIdConnectProvider.from_open_id_connect_provider_arn(
+            self, "OIDCProvider", oidc_provider_arn
+        )
+        # create IAM role for provider access from specified repo
+        # the role will allow a github action in that repo
+        # to deploy resources and read a secret
+        oidc_role = aws_iam.Role(
+            self,
+            f"veda-backend-oidc-role-{stage}",
+            assumed_by=aws_iam.WebIdentityPrincipal(
+                oidc_provider.open_id_connect_provider_arn,
+                conditions={
+                    "StringEquals": {
+                        f"{oidc_provider.open_id_connect_provider_issuer}:sub": f"repo:{oidc_repo_id}"
+                    }
+                },
+            ),
+        )
+        oidc_role.add_to_policy(
+            aws_iam.PolicyStatement(
+                actions=["sts:AssumeRoleWithWebIdentity"],
+                resources=[oidc_provider_arn],
+            )
+        )
+
+        # Create an IAM policy statement that allows getting the secret value
+        get_secret_statement = aws_iam.PolicyStatement(
+            effect=aws_iam.Effect.ALLOW,
+            actions=["secretsmanager:GetSecretValue"],
+            resources=[secret_arn],
+        )
+
+        oidc_policy = aws_iam.Policy(
+            self,
+            f"veda-backend-oidc-policy-{stage}",
+            policy_name=f"veda-backend-oidc-policy-{stage}",
+            roles=[oidc_role],
+            statements=[get_secret_statement],
+        )
+        return oidc_role, oidc_policy, oidc_provider
+
+    def build_env_secret(self, stage: str, env_config: dict) -> secretsmanager.ISecret:
+        """create secret to store environment variables"""
+        return secretsmanager.Secret(
+            self,
+            f"veda-backend-env-secret-{stage}",
+            secret_name=f"veda-backend-env-secret-{stage}",
+            description="Contains env vars used for deployment of veda-backend",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                secret_string_template=json.dumps(env_config),
+                generate_string_key="password",
+                exclude_punctuation=True,
+            ),
+        )
 
 
 veda_stack = VedaStack(
@@ -108,6 +179,78 @@ if stac_catalog_url:
         bucket_arn=website.bucket.bucket_arn,
     )
 
+db_secret_name = database.pgstac.secret.secret_name
+db_security_group = database.db_security_group
+
+# ingestor config requires references to other resources, but can be shared between ingest api and bulk ingestor
+ingestor_config = ingest_config(
+    stac_db_vpc_id=vpc.vpc.vpc_id,
+    stac_db_secret_name=db_secret_name,
+    stac_db_security_group_id=db_security_group.security_group_id,
+    stac_db_public_subnet=database.is_publicly_accessible,
+    stac_api_url=stac_api.stac_api.url,
+    raster_api_url=raster_api.raster_api.url,
+)
+
+env_secret = veda_stack.build_env_secret(
+    stage=veda_app_settings.stage_name(),
+    env_config=veda_app_settings.dict(),
+)
+
+
+if veda_app_settings.oidc_provider_arn:
+    oidc_resources = veda_stack.build_oidc(
+        oidc_provider_arn=veda_app_settings.oidc_provider_arn,
+        oidc_repo_id=veda_app_settings.oidc_repo_id,
+        secret_arn=env_secret.secret_arn,
+        stage=veda_app_settings.stage_name(),
+    )
+
+
+ingest_api = ingest_api_construct(
+    veda_stack,
+    "ingest-api",
+    config=ingestor_config,
+    db_secret=database.pgstac.secret,
+    db_vpc=vpc.vpc,
+)
+
+ingestor = ingestor_construct(
+    veda_stack,
+    "IngestorConstruct",
+    config=ingestor_config,
+    table=ingest_api.table,
+    db_secret=database.pgstac.secret,
+    db_vpc=vpc.vpc,
+)
+
+
+def register_ssm_parameter(
+    ctx: Construct,  # context for param init
+    name: str,
+    value: str,
+    description: str,
+) -> ssm.IStringParameter:
+    """Register SSM parameter"""
+    parameter_namespace = Stack.of(ctx).stack_name
+    return ssm.StringParameter(
+        ctx,
+        f"{name.replace('_', '-')}-parameter",
+        description=description,
+        parameter_name=f"/{parameter_namespace}/{name}",
+        string_value=value,
+    )
+
+
+def get_db_secret(
+    ctx: Construct, secret_name: str, stage: str
+) -> secretsmanager.ISecret:
+    """Get pgstac DB secret from Secrets Manager"""
+    return secretsmanager.Secret.from_secret_name_v2(
+        ctx, f"pgstac-db-secret-{stage}", secret_name
+    )
+
+
 # TODO this conditional supports deploying a second set of APIs to a separate custom domain and should be removed if no longer necessary
 if veda_app_settings.alt_domain():
     alt_domain = DomainConstruct(
@@ -136,11 +279,28 @@ if veda_app_settings.alt_domain():
         domain_name=alt_domain.stac_domain_name,
     )
 
+    alt_ingest_api = ingest_api_construct(
+        veda_stack,
+        "alt-ingest-api",
+        config=ingestor_config,
+        db_secret=database.pgstac.secret,
+        db_vpc=vpc.vpc,
+        domain_name=alt_domain.ingest_domain_name,
+    )
+
+git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+try:
+    git_tag = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
+except subprocess.CalledProcessError:
+    git_tag = "no-tag"
+
 for key, value in {
     "Project": veda_app_settings.app_name,
     "Stack": veda_app_settings.stage_name(),
     "Client": "nasa-impact",
-    "Owner": "ds",
+    "Owner": veda_app_settings.owner,
+    "GitCommit": git_sha,
+    "GitTag": git_tag,
 }.items():
     if value:
         Tags.of(app).add(key=key, value=value)

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import subprocess
 
 from aws_cdk import App, Aspects, Stack, Tags, aws_iam
 from aws_cdk import aws_secretsmanager as secretsmanager
-from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 from config import veda_app_settings
@@ -231,32 +230,6 @@ veda_routes.add_ingest_behavior(
 
 # Must be done after all CF behaviors exist
 veda_routes.create_route_records(stage=veda_app_settings.stage_name())
-
-
-def register_ssm_parameter(
-    ctx: Construct,  # context for param init
-    name: str,
-    value: str,
-    description: str,
-) -> ssm.IStringParameter:
-    """Register SSM parameter"""
-    parameter_namespace = Stack.of(ctx).stack_name
-    return ssm.StringParameter(
-        ctx,
-        f"{name.replace('_', '-')}-parameter",
-        description=description,
-        parameter_name=f"/{parameter_namespace}/{name}",
-        string_value=value,
-    )
-
-
-def get_db_secret(
-    ctx: Construct, secret_name: str, stage: str
-) -> secretsmanager.ISecret:
-    """Get pgstac DB secret from Secrets Manager"""
-    return secretsmanager.Secret.from_secret_name_v2(
-        ctx, f"pgstac-db-secret-{stage}", secret_name
-    )
 
 
 # TODO this conditional supports deploying a second set of APIs to a separate custom domain and should be removed if no longer necessary

--- a/app.py
+++ b/app.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 """ CDK Configuration for the veda-backend stack."""
 
-import json
 import subprocess
 
 from aws_cdk import App, Aspects, Stack, Tags, aws_iam
-from aws_cdk import aws_secretsmanager as secretsmanager
 from constructs import Construct
 
 from config import veda_app_settings
@@ -47,69 +45,6 @@ class VedaStack(Stack):
             )
             aws_iam.PermissionsBoundary.of(self).apply(permissions_boundary_policy)
             Aspects.of(self).add(PermissionsBoundaryAspect(permissions_boundary_policy))
-
-    # Core infrastructure, including secrets, OIDC (if enabled)
-
-    def build_oidc(
-        self, oidc_provider_arn: str, oidc_repo_id: str, secret_arn: str, stage: str
-    ):
-        """Create OIDC role and policy"""
-
-        # Locate an IAM OIDC provider for the specified provider ARN
-        oidc_provider = aws_iam.OpenIdConnectProvider.from_open_id_connect_provider_arn(
-            self, "OIDCProvider", oidc_provider_arn
-        )
-        # create IAM role for provider access from specified repo
-        # the role will allow a github action in that repo
-        # to deploy resources and read a secret
-        oidc_role = aws_iam.Role(
-            self,
-            f"veda-backend-oidc-role-{stage}",
-            assumed_by=aws_iam.WebIdentityPrincipal(
-                oidc_provider.open_id_connect_provider_arn,
-                conditions={
-                    "StringEquals": {
-                        f"{oidc_provider.open_id_connect_provider_issuer}:sub": f"repo:{oidc_repo_id}"
-                    }
-                },
-            ),
-        )
-        oidc_role.add_to_policy(
-            aws_iam.PolicyStatement(
-                actions=["sts:AssumeRoleWithWebIdentity"],
-                resources=[oidc_provider_arn],
-            )
-        )
-
-        # Create an IAM policy statement that allows getting the secret value
-        get_secret_statement = aws_iam.PolicyStatement(
-            effect=aws_iam.Effect.ALLOW,
-            actions=["secretsmanager:GetSecretValue"],
-            resources=[secret_arn],
-        )
-
-        oidc_policy = aws_iam.Policy(
-            self,
-            f"veda-backend-oidc-policy-{stage}",
-            policy_name=f"veda-backend-oidc-policy-{stage}",
-            roles=[oidc_role],
-            statements=[get_secret_statement],
-        )
-        return oidc_role, oidc_policy, oidc_provider
-
-    def build_env_secret(self, stage: str, env_config: dict) -> secretsmanager.ISecret:
-        """create secret to store environment variables"""
-        return secretsmanager.Secret(
-            self,
-            f"veda-backend-env-secret-{stage}",
-            secret_name=f"veda-backend-env-secret-{stage}",
-            description="Contains env vars used for deployment of veda-backend",
-            generate_secret_string=secretsmanager.SecretStringGenerator(
-                secret_string_template=json.dumps(env_config),
-                generate_string_key="password",
-                exclude_punctuation=True,
-            ),
-        )
 
 
 veda_stack = VedaStack(
@@ -190,20 +125,6 @@ ingestor_config = ingest_config(
     stac_api_url=stac_api.stac_api.url,
     raster_api_url=raster_api.raster_api.url,
 )
-
-env_secret = veda_stack.build_env_secret(
-    stage=veda_app_settings.stage_name(),
-    env_config=veda_app_settings.dict(),
-)
-
-
-if veda_app_settings.oidc_provider_arn:
-    oidc_resources = veda_stack.build_oidc(
-        oidc_provider_arn=veda_app_settings.oidc_provider_arn,
-        oidc_repo_id=veda_app_settings.oidc_repo_id,
-        secret_arn=env_secret.secret_arn,
-        stage=veda_app_settings.stage_name(),
-    )
 
 
 ingest_api = ingest_api_construct(

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ class vedaAppSettings(BaseSettings):
     permissions_boundary_policy_name: Optional[str] = Field(
         None,
         description="Name of IAM policy to define stack permissions boundary",
-    )
+    ) 
     veda_domain_alt_hosted_zone_id: Optional[str] = Field(
         None,
         description="Route53 zone identifier if using a custom domain name",

--- a/config.py
+++ b/config.py
@@ -67,14 +67,6 @@ class vedaAppSettings(BaseSettings):
         None,
         description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
     )
-    oidc_provider_arn: Optional[AwsOidcArn] = Field(  # type: ignore
-        description="ARN of AWS OIDC provider used for authentication"
-    )
-
-    oidc_repo_id: str = Field(
-        "NASA-IMPACT/veda-backend",
-        description="ID of AWS ECR repository used for OIDC provider",
-    )
 
     stac_browser_tag: Optional[str] = Field(
         "v3.1.0",

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ class vedaAppSettings(BaseSettings):
     permissions_boundary_policy_name: Optional[str] = Field(
         None,
         description="Name of IAM policy to define stack permissions boundary",
-    ) 
+    )
     veda_domain_alt_hosted_zone_id: Optional[str] = Field(
         None,
         description="Route53 zone identifier if using a custom domain name",

--- a/config.py
+++ b/config.py
@@ -1,7 +1,12 @@
 """App settings."""
+from getpass import getuser
 from typing import Optional
 
-from pydantic import BaseSettings, Field
+from pydantic import BaseSettings, Field, constr
+
+AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
+AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
+AwsOidcArn = constr(regex=r"^arn:aws:iam::\d{12}:oidc-provider/.+")
 
 
 class vedaAppSettings(BaseSettings):
@@ -19,6 +24,17 @@ class vedaAppSettings(BaseSettings):
             "i.e. `dev`, `staging`, `prod`"
         ),
     )
+    owner: str = Field(
+        description=" ".join(
+            [
+                "Name of primary contact for Cloudformation Stack.",
+                "Used to tag generated resources",
+                "Defaults to current username.",
+            ]
+        ),
+        default_factory=getuser,
+    )
+
     vpc_id: Optional[str] = Field(
         None,
         description=(
@@ -50,6 +66,14 @@ class vedaAppSettings(BaseSettings):
     bootstrap_qualifier: Optional[str] = Field(
         None,
         description="Custom bootstrap qualifier override if not using a default installation of AWS CDK Toolkit to synthesize app.",
+    )
+    oidc_provider_arn: Optional[AwsOidcArn] = Field(  # type: ignore
+        description="ARN of AWS OIDC provider used for authentication"
+    )
+
+    oidc_repo_id: str = Field(
+        "NASA-IMPACT/veda-backend",
+        description="ID of AWS ECR repository used for OIDC provider",
     )
 
     stac_browser_tag: Optional[str] = Field(

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -196,6 +196,8 @@ class RdsConstruct(Construct):
             database = aws_rds.DatabaseInstance(self, **database_config)
 
         hostname = database.instance_endpoint.hostname
+        self.db_security_group = database.connections.security_groups[0]
+        self.is_publicly_accessible = veda_db_settings.publicly_accessible
 
         # Use custom resource to bootstrap PgSTAC database
         self.pgstac = BootstrapPgStac(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - PGUSER=username
       - PGPASSWORD=password
       - PGDATABASE=postgis
-      - DYNAMODB_ENDPOINT=http://localhost:8084
+      - DYNAMODB_ENDPOINT=http://localhost:8085
     ports:
       - "8083:8083"
     command: bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && python /asset/local.py"
@@ -143,7 +143,7 @@ services:
     volumes:
       -  ./dynamodb-data:/home/dynamodblocal/data
     ports:
-      - 8084:8084
+      - 8085:8000 # skip 8084 for github actions to work
     command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data/"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,11 +107,45 @@ services:
       - PGDATABASE=postgis
     ports:
       - "5432:5432"
-    command: "postgres -N 500"
+    command: postgres -N 500
     volumes:
-      - ./.pgdata:/var/lib/postgresql/data
       - ./scripts:/tmp/scripts
       - ./.github/workflows/data:/tmp/data
+    # broken in github actions (definitely when run in act, possibly in tests involving ingest-api)? re-enable to persist local database
+    #  - ./.pgdata:/var/lib/postgresql/data
+
+  ingestor:
+    container_name: veda.ingestor
+    platform: linux/amd64
+    build:
+      context: .
+      dockerfile: local/Dockerfile.ingest
+    environment:
+      - POSTGRES_USER=username
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=postgis
+      - PGUSER=username
+      - PGPASSWORD=password
+      - PGDATABASE=postgis
+      - DYNAMODB_ENDPOINT=http://localhost:8084
+    ports:
+      - "8083:8083"
+    command: bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && python /asset/local.py"
+    volumes:
+      - ./scripts:/tmp/scripts
+      - $HOME/.aws/credentials:/root/.aws/credentials
+
+  dynamodb:
+    image:  amazon/dynamodb-local
+    container_name: veda.dynamodb
+    hostname: dynamodb
+    restart: always
+    volumes:
+      -  ./dynamodb-data:/home/dynamodblocal/data
+    ports:
+      - 8084:8084
+    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath /home/dynamodblocal/data/"
+
 
 networks:
   default:

--- a/domain/infrastructure/construct.py
+++ b/domain/infrastructure/construct.py
@@ -29,6 +29,7 @@ class DomainConstruct(Construct):
 
         self.stac_domain_name = None
         self.raster_domain_name = None
+        self.ingest_domain_name = None
 
         if veda_domain_settings.create_custom_subdomains:
             # If alternative custom domain provided, use it instead of the default
@@ -58,11 +59,14 @@ class DomainConstruct(Construct):
             if veda_domain_settings.api_prefix:
                 raster_url_prefix = f"{veda_domain_settings.api_prefix.lower()}-raster"
                 stac_url_prefix = f"{veda_domain_settings.api_prefix.lower()}-stac"
+                ingest_url_prefix = f"{veda_domain_settings.api_prefix.lower()}-ingest"
             else:
                 raster_url_prefix = f"{stage.lower()}-raster"
                 stac_url_prefix = f"{stage.lower()}-stac"
+                ingest_url_prefix = f"{stage.lower()}-ingest"
             raster_domain_name = f"{raster_url_prefix}.{hosted_zone_name}"
             stac_domain_name = f"{stac_url_prefix}.{hosted_zone_name}"
+            ingest_domain_name = f"{ingest_url_prefix}.{hosted_zone_name}"
 
             self.raster_domain_name = aws_apigatewayv2_alpha.DomainName(
                 self,
@@ -106,6 +110,27 @@ class DomainConstruct(Construct):
                 record_name=stac_url_prefix,
             )
 
+            self.ingest_domain_name = aws_apigatewayv2_alpha.DomainName(
+                self,
+                "ingestApiCustomDomain",
+                domain_name=ingest_domain_name,
+                certificate=certificate,
+            )
+
+            aws_route53.ARecord(
+                self,
+                "ingest-api-dns-record",
+                zone=hosted_zone,
+                target=aws_route53.RecordTarget.from_alias(
+                    aws_route53_targets.ApiGatewayv2DomainProperties(
+                        regional_domain_name=self.ingest_domain_name.regional_domain_name,
+                        regional_hosted_zone_id=self.ingest_domain_name.regional_hosted_zone_id,
+                    )
+                ),
+                # Note: CDK will append the hosted zone name (eg: `veda-backend.xyz` to this record name)
+                record_name=ingest_url_prefix,
+            )
+
             CfnOutput(
                 self,
                 "raster-api",
@@ -115,4 +140,9 @@ class DomainConstruct(Construct):
                 self,
                 "stac-api",
                 value=f"https://{stac_url_prefix}.{hosted_zone_name}/",
+            )
+            CfnOutput(
+                self,
+                "ingest-api",
+                value=f"https://{ingest_url_prefix}.{hosted_zone_name}/",
             )

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -1,4 +1,5 @@
 from getpass import getuser
+from typing import Optional
 
 import aws_cdk
 from pydantic import BaseSettings, Field, constr
@@ -56,9 +57,13 @@ class IngestorConfig(BaseSettings):
         description="URL of Raster API used to serve asset tiles"
     )
 
+    ingest_root_path: str = Field(description="Root path for ingest API")
+    custom_host: Optional[str] = Field(description="Custom host name")
+
     class Config:
         case_sensitive = False
         env_file = ".env"
+        env_prefix = "VEDA_"
 
     @property
     def stack_name(self) -> str:

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -47,7 +47,7 @@ class IngestorConfig(BaseSettings):
         default=True,
     )
 
-    data_access_role_arn: AwsArn = Field(  # type: ignore
+    raster_data_access_role_arn: AwsArn = Field(  # type: ignore
         description="ARN of AWS Role used to validate access to S3 data"
     )
 

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -1,0 +1,72 @@
+from getpass import getuser
+
+import aws_cdk
+from pydantic import BaseSettings, Field, constr
+
+AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
+AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
+AwsOidcArn = constr(regex=r"^arn:aws:iam::\d{12}:oidc-provider/.+")
+
+
+class IngestorConfig(BaseSettings):
+    stage: str = Field(
+        description=" ".join(
+            [
+                "Stage of deployment (e.g. 'dev', 'prod').",
+                "Used as suffix for stack name.",
+                "Defaults to current username.",
+            ]
+        ),
+        default_factory=getuser,
+    )
+    owner: str = Field(
+        description=" ".join(
+            [
+                "Name of primary contact for Cloudformation Stack.",
+                "Used to tag generated resources",
+                "Defaults to current username.",
+            ]
+        ),
+        default_factory=getuser,
+    )
+
+    userpool_id: str = Field(description="The Cognito Userpool used for authentication")
+    client_id: str = Field(description="The Cognito APP client ID")
+    client_secret: str = Field(description="The Cognito APP client secret")
+
+    stac_db_secret_name: str = Field(
+        description="Name of secret containing pgSTAC DB connection information"
+    )
+    stac_db_vpc_id: str = Field(description="ID of VPC running pgSTAC DB")
+    stac_db_security_group_id: str = Field(
+        description="ID of Security Group used by pgSTAC DB"
+    )
+    stac_db_public_subnet: bool = Field(
+        description="Boolean indicating whether or not pgSTAC DB is in a public subnet",
+        default=True,
+    )
+
+    data_access_role_arn: AwsArn = Field(  # type: ignore
+        description="ARN of AWS Role used to validate access to S3 data"
+    )
+
+    stac_api_url: str = Field(description="URL of STAC API used to serve STAC Items")
+
+    raster_api_url: str = Field(
+        description="URL of Raster API used to serve asset tiles"
+    )
+
+    class Config:
+        case_sensitive = False
+        env_file = ".env"
+
+    @property
+    def stack_name(self) -> str:
+        return f"veda-stac-ingestion-{self.stage}"
+
+    @property
+    def env(self) -> aws_cdk.Environment:
+        return aws_cdk.Environment(
+            account=self.aws_account,
+            region=self.aws_region,
+        )

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -1,4 +1,5 @@
 import os
+import typing
 from typing import Dict, Optional
 
 from aws_cdk import CfnOutput, Duration, RemovalPolicy, Stack
@@ -15,6 +16,9 @@ from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
 from .config import IngestorConfig
+
+if typing.TYPE_CHECKING:
+    from domain.infrastructure.construct import DomainConstruct
 
 
 class ApiConstruct(Construct):
@@ -176,7 +180,7 @@ class ApiConstruct(Construct):
         construct_id: str,
         handler: aws_lambda.IFunction,
         domain,
-        custom_host: str,
+        custom_host: Optional[str],
     ) -> aws_apigatewayv2_alpha.HttpApi:
 
         integration_kwargs = dict(handler=handler)

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -36,7 +36,7 @@ class ApiConstruct(Construct):
 
         self.table = self.build_table()
         self.data_access_role = iam.Role.from_role_arn(
-            self, "data-access-role", config.data_access_role_arn
+            self, "data-access-role", config.raster_data_access_role_arn
         )
 
         self.user_pool = cognito.UserPool.from_user_pool_id(
@@ -54,7 +54,7 @@ class ApiConstruct(Construct):
             "JWKS_URL": self.jwks_url,
             "NO_PYDANTIC_SSM_SETTINGS": "1",
             "STAC_URL": config.stac_api_url,
-            "DATA_ACCESS_ROLE_ARN": config.data_access_role_arn,
+            "DATA_ACCESS_ROLE_ARN": config.raster_data_access_role_arn,
             "USERPOOL_ID": config.userpool_id,
             "CLIENT_ID": config.client_id,
             "CLIENT_SECRET": config.client_secret,
@@ -258,7 +258,7 @@ class IngestorConstruct(Construct):
             "DYNAMODB_TABLE": table.table_name,
             "NO_PYDANTIC_SSM_SETTINGS": "1",
             "STAC_URL": config.stac_api_url,
-            "DATA_ACCESS_ROLE_ARN": config.data_access_role_arn,
+            "DATA_ACCESS_ROLE_ARN": config.raster_data_access_role_arn,
             "USERPOOL_ID": config.userpool_id,
             "CLIENT_ID": config.client_id,
             "CLIENT_SECRET": config.client_secret,

--- a/ingest_api/infrastructure/constructs.py
+++ b/ingest_api/infrastructure/constructs.py
@@ -1,0 +1,330 @@
+import os
+from typing import Dict
+
+from aws_cdk import Duration, RemovalPolicy, Stack
+from aws_cdk import aws_apigateway as apigateway
+from aws_cdk import aws_cognito as cognito
+from aws_cdk import aws_dynamodb as dynamodb
+from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_iam as iam
+from aws_cdk import aws_lambda
+from aws_cdk import aws_lambda_event_sources as events
+from aws_cdk import aws_secretsmanager as secretsmanager
+from aws_cdk import aws_ssm as ssm
+from constructs import Construct
+
+from .config import IngestorConfig
+
+
+class ApiConstruct(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        config: IngestorConfig,
+        db_secret: secretsmanager.ISecret,
+        db_vpc: ec2.IVpc,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.table = self.build_table()
+        self.data_access_role = iam.Role.from_role_arn(
+            self, "data-access-role", config.data_access_role_arn
+        )
+
+        self.user_pool = cognito.UserPool.from_user_pool_id(
+            self, "cognito-user-pool", config.userpool_id
+        )
+        self.jwks_url = self.build_jwks_url(config.userpool_id)
+        db_security_group = ec2.SecurityGroup.from_security_group_id(
+            self,
+            "db-security-group",
+            security_group_id=config.stac_db_security_group_id,
+        )
+
+        lambda_env = {
+            "DYNAMODB_TABLE": self.table.table_name,
+            "JWKS_URL": self.jwks_url,
+            "ROOT_PATH": f"/{config.stage}",
+            "NO_PYDANTIC_SSM_SETTINGS": "1",
+            "STAC_URL": config.stac_api_url,
+            "DATA_ACCESS_ROLE": config.data_access_role_arn,
+            "USERPOOL_ID": config.userpool_id,
+            "CLIENT_ID": config.client_id,
+            "CLIENT_SECRET": config.client_secret,
+            "RASTER_URL": config.raster_api_url,
+        }
+
+        # create lambda
+        self.api_lambda = self.build_api_lambda(
+            table=self.table,
+            env=lambda_env,
+            data_access_role=self.data_access_role,
+            user_pool=self.user_pool,
+            stage=config.stage,
+            db_secret=db_secret,
+            db_vpc=db_vpc,
+            db_security_group=db_security_group,
+            db_subnet_public=config.stac_db_public_subnet,
+        )
+
+        # create API
+        self.api = self.build_api(
+            handler=self.api_lambda,
+            stage=config.stage,
+        )
+
+        register_ssm_parameter(
+            self,
+            name="jwks_url",
+            value=self.jwks_url,
+            description="JWKS URL for Cognito user pool",
+        )
+        register_ssm_parameter(
+            self,
+            name="dynamodb_table",
+            value=self.table.table_name,
+            description="Name of table used to store ingestions",
+        )
+
+    def build_api_lambda(
+        self,
+        *,
+        table: dynamodb.ITable,
+        env: Dict[str, str],
+        data_access_role: iam.IRole,
+        user_pool: cognito.IUserPool,
+        stage: str,
+        db_secret: secretsmanager.ISecret,
+        db_vpc: ec2.IVpc,
+        db_security_group: ec2.ISecurityGroup,
+        db_subnet_public: bool,
+        code_dir: str = "./",
+    ) -> apigateway.LambdaRestApi:
+        handler_role = iam.Role(
+            self,
+            "execution-role",
+            description=(
+                "Role used by STAC Ingestor. Manually defined so that we can choose a "
+                "name that is supported by the data access roles trust policy"
+            ),
+            role_name=f"delta-backend-staging-stac-ingestion-api-{stage}",
+            assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(
+                    "service-role/AWSLambdaVPCAccessExecutionRole"
+                )
+            ],
+        )
+        handler = aws_lambda.Function(
+            self,
+            "api-handler",
+            code=aws_lambda.Code.from_docker_build(
+                path=os.path.abspath(code_dir),
+                file="ingest_api/runtime/Dockerfile",
+                platform="linux/amd64",
+            ),
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            timeout=Duration.seconds(30),
+            handler="handler.handler",
+            role=handler_role,
+            environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
+            vpc=db_vpc,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PUBLIC
+                if db_subnet_public
+                else ec2.SubnetType.PRIVATE_ISOLATED
+            ),
+            allow_public_subnet=True,
+            memory_size=2048,
+        )
+        table.grant_read_write_data(handler)
+        data_access_role.grant(
+            handler.grant_principal,
+            "sts:AssumeRole",
+        )
+
+        handler.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["cognito-idp:AdminInitiateAuth"],
+                resources=[user_pool.user_pool_arn],
+            )
+        )
+
+        # Allow handler to read DB secret
+        db_secret.grant_read(handler)
+
+        # Allow handler to connect to DB
+        db_security_group.add_ingress_rule(
+            peer=handler.connections.security_groups[0],
+            connection=ec2.Port.tcp(5432),
+            description="Allow connections from STAC Ingestor",
+        )
+        return handler
+
+    def build_api(
+        self,
+        *,
+        handler: aws_lambda.IFunction,
+        stage: str,
+    ) -> apigateway.LambdaRestApi:
+        return apigateway.LambdaRestApi(
+            self,
+            f"{Stack.of(self).stack_name}-api",
+            handler=handler,
+            cloud_watch_role=True,
+            deploy_options=apigateway.StageOptions(stage_name=stage),
+        )
+
+    def build_jwks_url(self, userpool_id: str) -> str:
+        region = userpool_id.split("_")[0]
+        return (
+            f"https://cognito-idp.{region}.amazonaws.com"
+            f"/{userpool_id}/.well-known/jwks.json"
+        )
+
+    # item ingest table, comsumed by ingestor
+    def build_table(self) -> dynamodb.ITable:
+        table = dynamodb.Table(
+            self,
+            "ingestions-table",
+            partition_key={"name": "created_by", "type": dynamodb.AttributeType.STRING},
+            sort_key={"name": "id", "type": dynamodb.AttributeType.STRING},
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
+            removal_policy=RemovalPolicy.DESTROY,
+            stream=dynamodb.StreamViewType.NEW_IMAGE,
+        )
+        table.add_global_secondary_index(
+            index_name="status",
+            partition_key={"name": "status", "type": dynamodb.AttributeType.STRING},
+            sort_key={"name": "created_at", "type": dynamodb.AttributeType.STRING},
+        )
+        return table
+
+
+class IngestorConstruct(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        config: IngestorConfig,
+        table: dynamodb.ITable,
+        db_secret: secretsmanager.ISecret,
+        db_vpc: ec2.IVpc,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+        # continue with ingestor-related methods (build_ingestor, etc.)
+        lambda_env = {
+            "DYNAMODB_TABLE": table.table_name,
+            "ROOT_PATH": f"/{config.stage}",
+            "NO_PYDANTIC_SSM_SETTINGS": "1",
+            "STAC_URL": config.stac_api_url,
+            "DATA_ACCESS_ROLE": config.data_access_role_arn,
+            "USERPOOL_ID": config.userpool_id,
+            "CLIENT_ID": config.client_id,
+            "CLIENT_SECRET": config.client_secret,
+            "RASTER_URL": config.raster_api_url,
+        }
+
+        db_security_group = ec2.SecurityGroup.from_security_group_id(
+            self,
+            "db-security-group",
+            security_group_id=config.stac_db_security_group_id,
+        )
+
+        self.ingest_lambda = self.build_ingestor(
+            table=table,
+            env=lambda_env,
+            db_secret=db_secret,
+            db_vpc=db_vpc,
+            db_security_group=db_security_group,
+            db_subnet_public=config.stac_db_public_subnet,
+        )
+
+    def build_ingestor(
+        self,
+        *,
+        table: dynamodb.ITable,
+        env: Dict[str, str],
+        db_secret: secretsmanager.ISecret,
+        db_vpc: ec2.IVpc,
+        db_security_group: ec2.ISecurityGroup,
+        db_subnet_public: bool,
+        code_dir: str = "./",
+    ) -> aws_lambda.Function:
+        handler = aws_lambda.Function(
+            self,
+            "stac-ingestor",
+            code=aws_lambda.Code.from_docker_build(
+                path=os.path.abspath(code_dir),
+                file="ingest_api/runtime/Dockerfile",
+                platform="linux/amd64",
+            ),
+            handler="ingestor.handler",
+            runtime=aws_lambda.Runtime.PYTHON_3_9,
+            timeout=Duration.seconds(180),
+            environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
+            vpc=db_vpc,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PUBLIC
+                if db_subnet_public
+                else ec2.SubnetType.PRIVATE_ISOLATED
+            ),
+            allow_public_subnet=True,
+            memory_size=2048,
+        )
+
+        # Allow handler to read DB secret
+        db_secret.grant_read(handler)
+
+        # Allow handler to connect to DB
+        db_security_group.add_ingress_rule(
+            peer=handler.connections.security_groups[0],
+            connection=ec2.Port.tcp(5432),
+            description="Allow connections from STAC Ingestor",
+        )
+
+        # Allow handler to write results back to DBƒ
+        table.grant_write_data(handler)
+
+        # Trigger handler from writes to DynamoDB table
+        handler.add_event_source(
+            events.DynamoEventSource(
+                table=table,
+                # Read when batches reach size...
+                batch_size=1000,
+                # ... or when window is reached.
+                max_batching_window=Duration.seconds(10),
+                # Read oldest data first.
+                starting_position=aws_lambda.StartingPosition.TRIM_HORIZON,
+                retry_attempts=1,
+            )
+        )
+
+        return handler
+
+
+def register_ssm_parameter(
+    ctx: Construct,  # context for param init
+    name: str,
+    value: str,
+    description: str,
+) -> ssm.IStringParameter:
+    parameter_namespace = Stack.of(ctx).stack_name
+    return ssm.StringParameter(
+        ctx,
+        f"{name.replace('_', '-')}-parameter",
+        description=description,
+        parameter_name=f"/{parameter_namespace}/{name}",
+        string_value=value,
+    )
+
+
+def get_db_secret(
+    ctx: Construct, secret_name: str, stage: str
+) -> secretsmanager.ISecret:
+    return secretsmanager.Secret.from_secret_name_v2(
+        ctx, f"pgstac-db-secret-{stage}", secret_name
+    )

--- a/ingest_api/runtime/Dockerfile
+++ b/ingest_api/runtime/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/sam/build-python3.9:latest
 
 WORKDIR /tmp
 
-COPY ingest_api/runtime /tmp/ingestor
+COPY ingest_api/runtime/requirements.txt /tmp/ingestor/requirements.txt
 RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic uvicorn
 RUN rm -rf /tmp/ingestor
 # TODO this is temporary until we use a real packaging system like setup.py or poetry

--- a/ingest_api/runtime/Dockerfile
+++ b/ingest_api/runtime/Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/sam/build-python3.9:latest
+
+WORKDIR /tmp
+
+COPY ingest_api/runtime /tmp/ingestor
+RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic uvicorn
+RUN rm -rf /tmp/ingestor
+# TODO this is temporary until we use a real packaging system like setup.py or poetry
+COPY ingest_api/runtime/src /asset/src
+
+# # Reduce package size and remove useless files
+RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+#RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
+
+COPY ingest_api/runtime/handler.py /asset/handler.py
+COPY ingest_api/runtime/ingestor.py /asset/ingestor.py
+
+CMD ["echo", "hello world"]

--- a/ingest_api/runtime/handler.py
+++ b/ingest_api/runtime/handler.py
@@ -1,0 +1,8 @@
+"""
+Entrypoint for Lambda execution.
+"""
+
+from mangum import Mangum
+from src.main import app
+
+handler = Mangum(app, lifespan="off")

--- a/ingest_api/runtime/handler.py
+++ b/ingest_api/runtime/handler.py
@@ -5,4 +5,4 @@ Entrypoint for Lambda execution.
 from mangum import Mangum
 from src.main import app
 
-handler = Mangum(app, lifespan="off")
+handler = Mangum(app, lifespan="off",api_gateway_base_path=app.root_path)

--- a/ingest_api/runtime/handler.py
+++ b/ingest_api/runtime/handler.py
@@ -5,4 +5,4 @@ Entrypoint for Lambda execution.
 from mangum import Mangum
 from src.main import app
 
-handler = Mangum(app, lifespan="off",api_gateway_base_path=app.root_path)
+handler = Mangum(app, lifespan="off", api_gateway_base_path=app.root_path)

--- a/ingest_api/runtime/ingestor.py
+++ b/ingest_api/runtime/ingestor.py
@@ -1,0 +1,7 @@
+"""
+Entrypoint for Lambda execution.
+"""
+
+import src.ingestor as ingestor
+
+handler = ingestor.handler

--- a/ingest_api/runtime/local.py
+++ b/ingest_api/runtime/local.py
@@ -1,0 +1,7 @@
+""" Script used to run the API locally"""
+
+import uvicorn
+from src import main
+
+if __name__ == "__main__":
+    uvicorn.run(main.app, host="0.0.0.0", port=8000)

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -1,0 +1,19 @@
+# Waiting for https://github.com/stac-utils/stac-pydantic/pull/116 and 117
+Authlib==1.0.1
+ddbcereal==2.1.1
+fastapi>=0.75.1
+fsspec==2023.3.0
+mangum>=0.15.0
+orjson>=3.6.8
+psycopg[binary,pool]>=3.0.15
+pydantic_ssm_settings>=0.2.0
+pydantic>=1.9.0
+pypgstac==0.7.4
+python-multipart==0.0.5
+requests>=2.27.1
+s3fs==2023.3.0
+stac-pydantic @ git+https://github.com/ividito/stac-pydantic.git@3f4cb381c85749bb4b15d1181179057ec0f51a94
+xarray==2023.1.0
+xstac==1.1.0
+zarr==2.13.6
+boto3==1.24.59

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -1,0 +1,107 @@
+import base64
+import hashlib
+import hmac
+import logging
+from typing import Dict
+
+import boto3
+import requests
+import src.config as config
+from authlib.jose import JsonWebKey, JsonWebToken, JWTClaims, KeySet, errors
+from cachetools import TTLCache, cached
+
+from fastapi import Depends, HTTPException, security
+
+logger = logging.getLogger(__name__)
+
+token_scheme = security.HTTPBearer()
+
+
+def get_settings() -> config.Settings:
+    import src.main as main
+
+    return main.settings
+
+
+def get_jwks_url(settings: config.Settings = Depends(get_settings)) -> str:
+    return settings.jwks_url
+
+
+@cached(TTLCache(maxsize=1, ttl=3600))
+def get_jwks(jwks_url: str = Depends(get_jwks_url)) -> KeySet:
+    with requests.get(jwks_url) as response:
+        response.raise_for_status()
+        return JsonWebKey.import_key_set(response.json())
+
+
+def decode_token(
+    token: security.HTTPAuthorizationCredentials = Depends(token_scheme),
+    jwks: KeySet = Depends(get_jwks),
+) -> JWTClaims:
+    """
+    Validate & decode JWT
+    """
+    try:
+        claims = JsonWebToken(["RS256"]).decode(
+            s=token.credentials,
+            key=jwks,
+            claims_options={
+                # # Example of validating audience to match expected value
+                # "aud": {"essential": True, "values": [APP_CLIENT_ID]}
+            },
+        )
+
+        if "client_id" in claims:
+            # Insert Cognito's `client_id` into `aud` claim if `aud` claim is unset
+            claims.setdefault("aud", claims["client_id"])
+
+        claims.validate()
+        return claims
+    except errors.JoseError:  #
+        logger.exception("Unable to decode token")
+        raise HTTPException(status_code=403, detail="Bad auth token")
+
+
+def get_username(claims: security.HTTPBasicCredentials = Depends(decode_token)):
+    return claims["sub"]
+
+
+def _get_secret_hash(username: str, client_id: str, client_secret: str) -> str:
+    # A keyed-hash message authentication code (HMAC) calculated using
+    # the secret key of a user pool client and username plus the client
+    # ID in the message.
+    message = username + client_id
+    dig = hmac.new(
+        bytearray(client_secret, "utf-8"),
+        msg=message.encode("UTF-8"),
+        digestmod=hashlib.sha256,
+    ).digest()
+    return base64.b64encode(dig).decode()
+
+
+def authenticate_and_get_token(
+    username: str,
+    password: str,
+    user_pool_id: str,
+    app_client_id: str,
+    app_client_secret: str,
+) -> Dict:
+    client = boto3.client("cognito-idp")
+    try:
+        resp = client.admin_initiate_auth(
+            UserPoolId=user_pool_id,
+            ClientId=app_client_id,
+            AuthFlow="ADMIN_USER_PASSWORD_AUTH",
+            AuthParameters={
+                "USERNAME": username,
+                "PASSWORD": password,
+                "SECRET_HASH": _get_secret_hash(
+                    username, app_client_id, app_client_secret
+                ),
+            },
+        )
+    except client.exceptions.NotAuthorizedException:
+        return {
+            "message": "Login failed, please make sure the credentials are correct."
+        }
+    return resp["AuthenticationResult"]

--- a/ingest_api/runtime/src/collection_publisher.py
+++ b/ingest_api/runtime/src/collection_publisher.py
@@ -1,0 +1,49 @@
+import os
+
+from pypgstac.db import PgstacDB
+from src.schemas import DashboardCollection
+from src.utils import (
+    IngestionType,
+    convert_decimals_to_float,
+    get_db_credentials,
+    load_into_pgstac,
+)
+from src.vedaloader import VEDALoader
+from stac_pydantic import Item
+
+
+class CollectionPublisher:
+    def ingest(self, collection: DashboardCollection):
+        """
+        Takes a collection model,
+        does necessary preprocessing,
+        and loads into the PgSTAC collection table
+        """
+        creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
+        collection = [convert_decimals_to_float(collection.dict(by_alias=True))]
+        with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
+            load_into_pgstac(
+                db=db, ingestions=collection, table=IngestionType.collections
+            )
+
+    def delete(self, collection_id: str):
+        """
+        Deletes the collection from the database
+        """
+        creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
+        with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
+            loader = VEDALoader(db=db)
+            loader.delete_collection(collection_id)
+
+
+class ItemPublisher:
+    def ingest(self, item: Item):
+        """
+        Takes an item model,
+        does necessary preprocessing,
+        and loads into the PgSTAC item table
+        """
+        creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
+        item = [convert_decimals_to_float(item.dict(by_alias=True))]
+        with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
+            load_into_pgstac(db=db, ingestions=item, table=IngestionType.items)

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -10,8 +10,6 @@ AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
 class Settings(BaseSettings):
     dynamodb_table: str
 
-    root_path: Optional[str] = Field(description="Path from where to serve this URL.")
-
     jwks_url: AnyHttpUrl = Field(
         description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json"  # noqa
     )
@@ -24,7 +22,8 @@ class Settings(BaseSettings):
 
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: str = Field(description="The Cognito APP client secret")
-
+    root_path: str = Field(description="Root path of API")
+    stage: str = Field(description='API stage')
     class Config(AwsSsmSourceConfig):
         env_file = ".env"
 

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import AnyHttpUrl, BaseSettings, Field, constr
 from pydantic_ssm_settings import AwsSsmSourceConfig
 
@@ -23,7 +21,8 @@ class Settings(BaseSettings):
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: str = Field(description="The Cognito APP client secret")
     root_path: str = Field(description="Root path of API")
-    stage: str = Field(description='API stage')
+    stage: str = Field(description="API stage")
+
     class Config(AwsSsmSourceConfig):
         env_file = ".env"
 

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from pydantic import AnyHttpUrl, BaseSettings, Field, constr
+from pydantic_ssm_settings import AwsSsmSourceConfig
+
+AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
+AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
+
+
+class Settings(BaseSettings):
+    dynamodb_table: str
+
+    root_path: Optional[str] = Field(description="Path from where to serve this URL.")
+
+    jwks_url: AnyHttpUrl = Field(
+        description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json"  # noqa
+    )
+
+    data_access_role_arn: AwsArn = Field(  # type: ignore
+        description="ARN of AWS Role used to validate access to S3 data"
+    )
+
+    userpool_id: str = Field(description="The Cognito Userpool used for authentication")
+
+    client_id: str = Field(description="The Cognito APP client ID")
+    client_secret: str = Field(description="The Cognito APP client secret")
+
+    class Config(AwsSsmSourceConfig):
+        env_file = ".env"
+
+    @classmethod
+    def from_ssm(cls, stack: str):
+        return cls(_secrets_dir=f"/{stack}")

--- a/ingest_api/runtime/src/dependencies.py
+++ b/ingest_api/runtime/src/dependencies.py
@@ -1,0 +1,34 @@
+import logging
+
+import boto3
+import src.auth as auth
+import src.config as config
+import src.services as services
+
+from fastapi import Depends, HTTPException, security
+
+logger = logging.getLogger(__name__)
+
+token_scheme = security.HTTPBearer()
+
+
+def get_table(settings: config.Settings = Depends(auth.get_settings)):
+    client = boto3.resource("dynamodb")
+    return client.Table(settings.dynamodb_table)
+
+
+def get_db(table=Depends(get_table)) -> services.Database:
+    return services.Database(table=table)
+
+
+def fetch_ingestion(
+    ingestion_id: str,
+    db: services.Database = Depends(get_db),
+    username: str = Depends(auth.get_username),
+):
+    try:
+        return db.fetch_one(username=username, ingestion_id=ingestion_id)
+    except services.NotInDb:
+        raise HTTPException(
+            status_code=404, detail="No ingestion found with provided ID"
+        )

--- a/ingest_api/runtime/src/doc.py
+++ b/ingest_api/runtime/src/doc.py
@@ -1,0 +1,103 @@
+DESCRIPTION = """
+# Overview
+The VEDA STAC Ingestor is a service that allows users and other services to add new
+ records to the STAC database in order to manage geo spatial data.
+It performs validation on the records, called STAC items, to ensure that they meet the
+ STAC specification, all assets are accessible, and their collection exists. The
+  service also performs other operations on the records.
+
+# Usage
+
+## Auth
+The auth API allows users to retrieve an access token and get information about the
+ current user.
+To get an access token, the user must provide their username and password in the
+ request body to the POST `/token` API.
+The current user's information can be retrieved using the GET `/auth/me` API.
+
+Before using the API, user must ask a VEDA team member to create credentials (username
+ and password) for VEDA auth.
+The user name and password is used to get the access token from Auth API call in order
+ to authorize the execution of API.
+
+## Ingestions
+
+The ingestion API allows users to create, cancel, update, and retrieve information
+ about STAC item ingests.
+
+The `/ingestions/` endpoint includes a GET endpoint to list ingests based on their
+ status.
+The endpoint takes a single query parameter, `status`, which should be selected from a
+ predefined set of allowed values in the form of a dropdown list.
+
+The allowed values for the `status` parameter are:
+
+* "started": Ingests that have started processing
+* "queued": Ingests that are waiting to be processed
+* "failed": Ingests that have failed during processing
+* "succeeded": Ingests that have been successfully processed
+* "cancelled": Ingests that were cancelled before completing
+
+To create an ingestion, the user must provide the following information in the request
+ body to the POST `/ingestions` API:
+The API allows creating a new ingestion, which includes validating and processing a
+ STAC item, and adding it to the STAC database.
+The request body should be in JSON format and should contain the fields that specifies
+ a STAC item. `https://stacspec.org/en/tutorials/intro-to-stac/#STAC-Item`
+
+The `/ingestions/{ingestion_id}` GET endpoint allows retrieving information about a
+ specific ingestion, including its current status and other metadata.
+
+To cancel an ingestion, the user must provide the ingestion id to the DELETE
+ `/ingestions/{ingestion_id}` API.
+
+To update an ingestion, the user must provide the ingestion id and the new information
+ to the PUT `/ingestions/{ingestion_id}` API.
+
+## Collections
+The collection API is used to create a new STAC collection dataset.
+The input to the collection API is a STAC collection which follows the STAC
+ collection specification.
+     `https://github.com/radiantearth/stac-spec/blob/v1.0.0/collection-spec/collection-spec.md`
+
+Following is a sample input for collection API:
+```
+{
+  "id": "collection-id",
+  "title": "Collection Title",
+  "description": "A detailed description of the collection",
+  "license": "LICENSE",
+  "extent": {
+    "spatial": [
+      WEST, SOUTH,
+      EAST, NORTH
+    ],
+    "temporal": [
+      "START_DATE",
+      "END_DATE"
+    ]
+  },
+  "providers": [
+    {
+      "name": "Provider Name",
+      "roles": ["role1", "role2"],
+      "url": "http://example.com"
+    }
+  ],
+  "stac_version": "STAC_VERSION",
+  "links": [
+    {
+      "rel": "self",
+      "href": "http://example.com/stac/collection-id"
+    },
+    {
+      "rel": "items",
+      "href": "http://example.com/stac/collection-id/items"
+    }
+  ]
+}
+```
+
+To delete a collection, the user must provide the collection id to the `collections/
+collection_id` API.
+"""

--- a/ingest_api/runtime/src/ingestor.py
+++ b/ingest_api/runtime/src/ingestor.py
@@ -1,0 +1,99 @@
+import os
+import traceback
+from datetime import datetime
+from typing import TYPE_CHECKING, Iterator, List, Optional, Sequence
+
+from boto3.dynamodb.types import TypeDeserializer
+from pypgstac.db import PgstacDB
+from src.auth import get_settings
+from src.dependencies import get_table
+from src.schemas import Ingestion, Status
+from src.utils import (
+    IngestionType,
+    convert_decimals_to_float,
+    get_db_credentials,
+    load_into_pgstac,
+)
+
+if TYPE_CHECKING:
+    from aws_lambda_typing import context as context_
+    from aws_lambda_typing import events
+    from aws_lambda_typing.events.dynamodb_stream import DynamodbRecord
+
+
+def get_queued_ingestions(records: List["DynamodbRecord"]) -> Iterator[Ingestion]:
+    deserializer = TypeDeserializer()
+    for record in records:
+        # Parse Record
+        parsed = {
+            k: deserializer.deserialize(v)
+            for k, v in record["dynamodb"]["NewImage"].items()
+        }
+        ingestion = Ingestion.parse_obj(parsed)
+        if ingestion.status == Status.queued:
+            yield ingestion
+
+
+def update_dynamodb(
+    ingestions: Sequence[Ingestion],
+    status: Status,
+    message: Optional[str] = None,
+):
+    """
+    Bulk update DynamoDB with ingestion results.
+    """
+    # Update records in DynamoDB
+    print(f"Updating ingested items status in DynamoDB, marking as {status}...")
+    table = get_table(get_settings())
+    with table.batch_writer(overwrite_by_pkeys=["created_by", "id"]) as batch:
+        for ingestion in ingestions:
+            batch.put_item(
+                Item=ingestion.copy(
+                    update={
+                        "status": status,
+                        "message": message,
+                        "updated_at": datetime.now(),
+                    }
+                ).dynamodb_dict()
+            )
+
+
+def handler(event: "events.DynamoDBStreamEvent", context: "context_.Context"):
+    # Parse input
+    ingestions = list(get_queued_ingestions(event["Records"]))
+    if not ingestions:
+        print("No queued ingestions to process")
+        return
+
+    items = [
+        # NOTE: Important to deserialize values to convert decimals to floats
+        convert_decimals_to_float(ingestion.item)
+        for ingestion in ingestions
+    ]
+
+    creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
+
+    # Insert into PgSTAC DB
+    outcome = Status.succeeded
+    message = None
+    try:
+        with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
+            load_into_pgstac(
+                db=db,
+                ingestions=items,
+                table=IngestionType.items,
+            )
+    except Exception as e:
+        traceback.print_exc()
+        print(f"Encountered failure loading items into pgSTAC: {e}")
+        outcome = Status.failed
+        message = str(e)
+
+    # Update DynamoDB with outcome
+    update_dynamodb(
+        ingestions=ingestions,
+        status=outcome,
+        message=message,
+    )
+
+    print("Completed batch...")

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -27,14 +27,16 @@ settings = (
 
 
 app = FastAPI(
-    root_path=settings.root_path,
-    title="VEDA Ingestion API Documentation",
+    title="VEDA Ingestion API",
     description=DESCRIPTION,
     license_info={
         "name": "Apache 2.0",
         "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
     },
     contact={"url": "https://github.com/NASA-IMPACT/veda-backend"},
+    root_path=settings.root_path,
+    openapi_url="/openapi.json",
+    docs_url="/docs",
 )
 
 collection_publisher = CollectionPublisher()

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -1,0 +1,220 @@
+import os
+from getpass import getuser
+from typing import Dict
+
+import src.auth as auth
+import src.config as config
+import src.dependencies as dependencies
+import src.schemas as schemas
+import src.services as services
+from src.collection_publisher import CollectionPublisher, ItemPublisher
+from src.doc import DESCRIPTION
+
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.security import OAuth2PasswordRequestForm
+
+settings = (
+    config.Settings()
+    if os.environ.get("NO_PYDANTIC_SSM_SETTINGS")
+    else config.Settings.from_ssm(
+        stack=os.environ.get(
+            "STACK", f"veda-stac-ingestion-system-{os.environ.get('STAGE', getuser())}"
+        ),
+    )
+)
+
+
+app = FastAPI(
+    root_path=settings.root_path,
+    title="VEDA Ingestion API Documentation",
+    description=DESCRIPTION,
+    license_info={
+        "name": "Apache 2.0",
+        "url": "https://www.apache.org/licenses/LICENSE-2.0.html",
+    },
+    contact={"url": "https://github.com/NASA-IMPACT/veda-backend"},
+)
+
+collection_publisher = CollectionPublisher()
+item_publisher = ItemPublisher()
+
+
+@app.get(
+    "/ingestions", response_model=schemas.ListIngestionResponse, tags=["Ingestion"]
+)
+async def list_ingestions(
+    list_request: schemas.ListIngestionRequest = Depends(),
+    db: services.Database = Depends(dependencies.get_db),
+):
+    """
+    Lists the STAC items from ingestion.
+    """
+    return db.fetch_many(
+        status=list_request.status, next=list_request.next, limit=list_request.limit
+    )
+
+
+@app.post(
+    "/ingestions",
+    response_model=schemas.Ingestion,
+    tags=["Ingestion"],
+    status_code=201,
+)
+async def enqueue_ingestion(
+    item: schemas.AccessibleItem,
+    username: str = Depends(auth.get_username),
+    db: services.Database = Depends(dependencies.get_db),
+) -> schemas.Ingestion:
+    """
+    Queues a STAC item for ingestion.
+    """
+    return schemas.Ingestion(
+        id=item.id,
+        created_by=username,
+        item=item,
+        status=schemas.Status.queued,
+    ).enqueue(db)
+
+
+@app.get(
+    "/ingestions/{ingestion_id}",
+    response_model=schemas.Ingestion,
+    tags=["Ingestion"],
+)
+def get_ingestion(
+    ingestion: schemas.Ingestion = Depends(dependencies.fetch_ingestion),
+) -> schemas.Ingestion:
+    """
+    Gets the status of an ingestion.
+    """
+    return ingestion
+
+
+@app.patch(
+    "/ingestions/{ingestion_id}",
+    response_model=schemas.Ingestion,
+    tags=["Ingestion"],
+)
+def update_ingestion(
+    update: schemas.UpdateIngestionRequest,
+    ingestion: schemas.Ingestion = Depends(dependencies.fetch_ingestion),
+    db: services.Database = Depends(dependencies.get_db),
+):
+    """
+    Updates the STAC item with the provided item.
+    """
+    updated_item = ingestion.copy(update=update.dict(exclude_unset=True))
+    return updated_item.save(db)
+
+
+@app.delete(
+    "/ingestions/{ingestion_id}",
+    response_model=schemas.Ingestion,
+    tags=["Ingestion"],
+)
+def cancel_ingestion(
+    ingestion: schemas.Ingestion = Depends(dependencies.fetch_ingestion),
+    db: services.Database = Depends(dependencies.get_db),
+) -> schemas.Ingestion:
+    """
+    Cancels an ingestion in queued state."""
+    if ingestion.status != schemas.Status.queued:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Unable to delete ingestion if status is not "
+                f"{schemas.Status.queued}"
+            ),
+        )
+    return ingestion.cancel(db)
+
+
+@app.post(
+    "/collections",
+    tags=["Collection"],
+    status_code=201,
+    dependencies=[Depends(auth.get_username)],
+)
+def publish_collection(collection: schemas.DashboardCollection):
+    """
+    Publish a collection to the STAC database.
+    """
+    # pgstac create collection
+    try:
+        collection_publisher.ingest(collection)
+        return {f"Successfully published: {collection.id}"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Unable to publish collection: {e}"),
+        )
+
+
+@app.delete(
+    "/collections/{collection_id}",
+    tags=["Collection"],
+    dependencies=[Depends(auth.get_username)],
+)
+def delete_collection(collection_id: str):
+    """
+    Delete a collection from the STAC database.
+    """
+    try:
+        collection_publisher.delete(collection_id=collection_id)
+        return {f"Successfully deleted: {collection_id}"}
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=400, detail=(f"{e}"))
+
+
+@app.post(
+    "/items",
+    tags=["Items"],
+    status_code=201,
+    dependencies=[Depends(auth.get_username)],
+)
+def publish_item(item: schemas.Item):
+    """
+    Publish a collection to the STAC database.
+    """
+    # pgstac create collection
+    try:
+        item_publisher.ingest(item)
+        return {f"Successfully published: {item.id}"}
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"Unable to publish collection: {e}"),
+        )
+
+
+@app.post("/token", tags=["Auth"], response_model=schemas.AuthResponse)
+async def get_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+) -> Dict:
+    """
+    Get token from username and password
+    """
+    return auth.authenticate_and_get_token(
+        form_data.username,
+        form_data.password,
+        settings.userpool_id,
+        settings.client_id,
+        settings.client_secret,
+    )
+
+
+@app.get("/auth/me", tags=["Auth"], response_model=schemas.WhoAmIResponse)
+def who_am_i(claims=Depends(auth.decode_token)):
+    """
+    Return claims for the provided JWT
+    """
+    return claims
+
+
+# exception handling
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request, exc):
+    return JSONResponse(str(exc), status_code=422)

--- a/ingest_api/runtime/src/schema_helpers.py
+++ b/ingest_api/runtime/src/schema_helpers.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+from typing import List, Union
+
+from pydantic import BaseModel, root_validator
+from stac_pydantic.collection import Extent, TimeInterval
+
+# Smaller utility models to support the larger models in schemas.py
+
+
+class DatetimeInterval(TimeInterval):
+    # reimplement stac_pydantic's TimeInterval to leverage datetime types
+    interval: List[List[Union[datetime, None]]]
+
+
+class SpatioTemporalExtent(Extent):
+    # reimplement stac_pydantic's Extent to leverage datetime types
+    temporal: DatetimeInterval
+
+
+# TODO we should make these more consistent with stac_pydantic's existing models
+class BboxExtent(BaseModel):
+    xmin: float
+    ymin: float
+    xmax: float
+    ymax: float
+
+    @root_validator
+    def check_extent(cls, v):
+        # mins must be below maxes
+        if v["xmin"] >= v["xmax"] or v["ymin"] >= v["ymax"]:
+            raise ValueError(
+                "Invalid extent - xmin must be less than xmax, ymin less than ymax"
+            )
+        # ys must be within -90 and 90, x between -180 and 180
+        if v["xmin"] < -180 or v["xmax"] > 180 or v["ymin"] < -90 or v["ymax"] > 90:
+            raise ValueError(
+                "Invalid extent - coordinates must be within -180, 180 and -90, 90"
+            )
+        return v
+
+
+class TemporalExtent(BaseModel):
+    startdate: datetime
+    enddate: datetime
+
+    @root_validator
+    def check_dates(cls, v):
+        if v["startdate"] >= v["enddate"]:
+            raise ValueError("Invalid extent - startdate must be before enddate")
+        return v

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -1,0 +1,207 @@
+import base64
+import binascii
+import enum
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Dict, List, Optional
+from urllib.parse import urlparse
+
+import src.validators as validators
+from pydantic import (
+    BaseModel,
+    Field,
+    PositiveInt,
+    error_wrappers,
+    root_validator,
+    validator,
+)
+from src.schema_helpers import SpatioTemporalExtent
+from stac_pydantic import Collection, Item, shared
+from stac_pydantic.links import Link
+
+from fastapi.exceptions import RequestValidationError
+
+if TYPE_CHECKING:
+    from src import services
+
+
+class AccessibleAsset(shared.Asset):
+    @validator("href")
+    def is_accessible(cls, href):
+        url = urlparse(href)
+
+        if url.scheme in ["https", "http"]:
+            validators.url_is_accessible(href)
+        elif url.scheme in ["s3"]:
+            validators.s3_object_is_accessible(
+                bucket=url.hostname, key=url.path.lstrip("/")
+            )
+        else:
+            ValueError(f"Unsupported scheme: {url.scheme}")
+
+        return href
+
+
+class AccessibleItem(Item):
+    assets: Dict[str, AccessibleAsset]
+
+    @validator("collection")
+    def exists(cls, collection):
+        validators.collection_exists(collection_id=collection)
+        return collection
+
+
+class DashboardCollection(Collection):
+    is_periodic: Optional[bool] = Field(default=False, alias="dashboard:is_periodic")
+    time_density: Optional[str] = Field(default=None, alias="dashboard:time_density")
+    item_assets: Optional[Dict]
+    links: Optional[List[Link]]
+    assets: Optional[Dict]
+    extent: SpatioTemporalExtent
+
+    class Config:
+        allow_population_by_field_name = True
+
+    @validator("item_assets")
+    def cog_default_exists(cls, item_assets):
+        validators.cog_default_exists(item_assets)
+        return item_assets
+
+    @root_validator
+    def check_time_density(cls, values):
+        validators.time_density_is_valid(values["is_periodic"], values["time_density"])
+        return values
+
+
+class Status(str, enum.Enum):
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        return cls.unknown
+
+    started = "started"
+    queued = "queued"
+    failed = "failed"
+    succeeded = "succeeded"
+    cancelled = "cancelled"
+
+
+class AuthResponse(BaseModel):
+    AccessToken: str = Field(..., description="Token used to authenticate the user.")
+    ExpiresIn: int = Field(
+        ..., description="Number of seconds before the AccessToken expires."
+    )
+    TokenType: str = Field(
+        ..., description="Type of token being returned (e.g. 'Bearer')."
+    )
+    RefreshToken: str = Field(
+        ..., description="Token used to refresh the AccessToken when it expires."
+    )
+    IdToken: str = Field(
+        ..., description="Token containing information about the authenticated user."
+    )
+
+
+class WhoAmIResponse(BaseModel):
+    sub: str = Field(..., description="A unique identifier for the user")
+    cognito_groups: List[str] = Field(
+        ..., description="A list of Cognito groups the user belongs to"
+    )
+    iss: str = Field(..., description="The issuer of the token")
+    client_id: str = Field(..., description="The client ID of the authenticated app")
+    origin_jti: str = Field(
+        ..., description="A unique identifier for the authentication event"
+    )
+    event_id: str = Field(..., description="A unique identifier for the event")
+    token_use: str = Field(..., description="The intended use of the token")
+    scope: str = Field(..., description="The scope of the token")
+    auth_time: int = Field(..., description="The time when the user was authenticated")
+    exp: int = Field(..., description="The time when the token will expire")
+    iat: int = Field(..., description="The time when the token was issued")
+    jti: str = Field(..., description="A unique identifier for the token")
+    username: str = Field(..., description="The username of the user")
+    aud: str = Field(..., description="The audience of the token")
+
+
+class Ingestion(BaseModel):
+    id: str = Field(..., description="ID of the STAC item")
+    status: Status = Field(..., description="Status of the ingestion")
+    message: Optional[str] = Field(
+        None, description="Message returned from the step function."
+    )
+    created_by: str = Field(..., description="User who created the ingestion")
+    created_at: datetime = Field(None, description="Timestamp of ingestion creation")
+    updated_at: datetime = Field(None, description="Timestamp of ingestion update")
+
+    item: Item = Field(..., description="STAC item to ingest")
+
+    @validator("created_at", pre=True, always=True, allow_reuse=True)
+    @validator("updated_at", pre=True, always=True, allow_reuse=True)
+    def set_ts_now(cls, v):
+        return v or datetime.now()
+
+    def enqueue(self, db: "services.Database"):
+        self.status = Status.queued
+        return self.save(db)
+
+    def cancel(self, db: "services.Database"):
+        self.status = Status.cancelled
+        return self.save(db)
+
+    def save(self, db: "services.Database"):
+        self.updated_at = datetime.now()
+        db.write(self)
+        return self
+
+    def dynamodb_dict(self, by_alias=True):
+        """DynamoDB-friendly serialization"""
+        return json.loads(self.json(by_alias=by_alias), parse_float=Decimal)
+
+
+class ListIngestionRequest(BaseModel):
+    status: Status = Field(Status.queued, description="Status of the ingestion")
+    limit: PositiveInt = Field(None, description="Limit number of results")
+    next: Optional[str] = Field(None, description="Next token (json) to load")
+
+    def __post_init_post_parse__(self) -> None:
+        # https://github.com/tiangolo/fastapi/issues/1474#issuecomment-1049987786
+        if self.next is None:
+            return
+
+        try:
+            self.next = json.loads(base64.b64decode(self.next))
+        except (UnicodeDecodeError, binascii.Error):
+            raise RequestValidationError(
+                [
+                    error_wrappers.ErrorWrapper(
+                        ValueError(
+                            "Unable to decode next token. Should be base64 encoded JSON"
+                        ),
+                        "query.next",
+                    )
+                ]
+            )
+
+
+class ListIngestionResponse(BaseModel):
+    items: List[Ingestion] = Field(
+        ..., description="List of STAC items from ingestion."
+    )
+    next: Optional[str] = Field(None, description="Next token (json) to load")
+
+    @validator("next", pre=True)
+    def b64_encode_next(cls, next):
+        """
+        Base64 encode next parameter for easier transportability
+        """
+        if isinstance(next, dict):
+            return base64.b64encode(json.dumps(next).encode())
+        return next
+
+
+class UpdateIngestionRequest(BaseModel):
+    status: Status = Field(None, description="Status of the ingestion")
+    message: str = Field(None, description="Message of the ingestion")

--- a/ingest_api/runtime/src/services.py
+++ b/ingest_api/runtime/src/services.py
@@ -1,0 +1,48 @@
+import decimal
+from typing import TYPE_CHECKING, List, Optional
+
+import src.schemas as schemas
+from boto3.dynamodb import conditions
+from boto3.dynamodb.types import DYNAMODB_CONTEXT
+from pydantic import parse_obj_as
+
+if TYPE_CHECKING:
+    from mypy_boto3_dynamodb.service_resource import Table
+
+
+DYNAMODB_CONTEXT.traps[decimal.Rounded] = 0
+
+
+class Database:
+    def __init__(self, table: "Table"):
+        self.table = table
+
+    def write(self, ingestion: schemas.Ingestion):
+        self.table.put_item(Item=ingestion.dynamodb_dict())
+
+    def fetch_one(self, username: str, ingestion_id: str):
+        response = self.table.get_item(
+            Key={"created_by": username, "id": ingestion_id},
+        )
+        try:
+            return schemas.Ingestion.parse_obj(response["Item"])
+        except KeyError:
+            raise NotInDb("Record not found")
+
+    def fetch_many(
+        self, status: str, next: Optional[dict] = None, limit: Optional[int] = None
+    ) -> schemas.ListIngestionResponse:
+        response = self.table.query(
+            IndexName="status",
+            KeyConditionExpression=conditions.Key("status").eq(status),
+            **{"Limit": limit} if limit else {},
+            **{"ExclusiveStartKey": next} if next else {},
+        )
+        return {
+            "items": parse_obj_as(List[schemas.Ingestion], response["Items"]),
+            "next": response.get("LastEvaluatedKey"),
+        }
+
+
+class NotInDb(Exception):
+    ...

--- a/ingest_api/runtime/src/utils.py
+++ b/ingest_api/runtime/src/utils.py
@@ -1,0 +1,107 @@
+import decimal
+import json
+from enum import Enum
+from typing import Any, Dict, Sequence, Union
+
+import boto3
+import orjson
+import pydantic
+from pypgstac.db import PgstacDB
+from pypgstac.load import Methods
+from src.schemas import AccessibleItem, DashboardCollection
+from src.vedaloader import VEDALoader
+
+
+class IngestionType(str, Enum):
+    collections = "collections"
+    items = "items"
+
+
+class DbCreds(pydantic.BaseModel):
+    username: str
+    password: str
+    host: str
+    port: int
+    dbname: str
+    engine: str
+
+    @property
+    def dsn_string(self) -> str:
+        return f"{self.engine}://{self.username}:{self.password}@{self.host}:{self.port}/{self.dbname}"  # noqa
+
+
+def get_db_credentials(secret_arn: str) -> DbCreds:
+    """
+    Load pgSTAC database credentials from AWS Secrets Manager.
+    """
+    print("Fetching DB credentials...")
+    session = boto3.session.Session(region_name=secret_arn.split(":")[3])
+    client = session.client(service_name="secretsmanager")
+    response = client.get_secret_value(SecretId=secret_arn)
+    return DbCreds.parse_raw(response["SecretString"])
+
+
+def convert_decimals_to_float(item: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    DynamoDB stores floats as Decimals. We want to convert them back to floats
+    before inserting them into pgSTAC to avoid any issues when the records are
+    converted to JSON by pgSTAC.
+    """
+
+    def decimal_to_float(obj):
+        if isinstance(obj, decimal.Decimal):
+            return float(obj)
+        raise TypeError
+
+    return json.loads(
+        orjson.dumps(
+            item,
+            default=decimal_to_float,
+        )
+    )
+
+
+def load_items(items: Sequence[AccessibleItem], loader):
+    """
+    Loads items into the PgSTAC database and
+    updates the summaries and extent for the collections involved
+    """
+    loading_result = loader.load_items(
+        file=items,
+        # use insert_ignore to avoid overwritting existing items or upsert to replace
+        insert_mode=Methods.upsert,
+    )
+
+    # Trigger update on summaries and extents
+    collections = set([item["collection"] for item in items])
+    for collection in collections:
+        loader.update_collection_summaries(collection)
+
+    return loading_result
+
+
+def load_collection(collection: Sequence[DashboardCollection], loader):
+    """
+    Loads the collection to the PgSTAC database
+    """
+    return loader.load_collections(
+        file=collection,
+        # use insert_ignore to avoid overwritting existing items or upsert to replace
+        insert_mode=Methods.upsert,
+    )
+
+
+def load_into_pgstac(
+    db: "PgstacDB",
+    ingestions: Union[Sequence[AccessibleItem], Sequence[DashboardCollection]],
+    table: IngestionType,
+):
+    """
+    Bulk insert STAC records into pgSTAC.
+    The ingestion can be items or collection, determined by the `table` arg.
+    """
+    loader = VEDALoader(db=db)
+    loading_function = load_items
+    if table == IngestionType.collections:
+        loading_function = load_collection  # type: ignore
+    return loading_function(ingestions, loader)

--- a/ingest_api/runtime/src/validators.py
+++ b/ingest_api/runtime/src/validators.py
@@ -1,0 +1,93 @@
+import functools
+from typing import Union
+
+import boto3
+import requests
+
+
+@functools.lru_cache
+def get_s3_credentials():
+    from src.main import settings
+
+    print("Fetching S3 Credentials...")
+
+    response = boto3.client("sts").assume_role(
+        RoleArn=settings.data_access_role_arn,
+        RoleSessionName="stac-ingestor-data-validation",
+    )
+    return {
+        "aws_access_key_id": response["Credentials"]["AccessKeyId"],
+        "aws_secret_access_key": response["Credentials"]["SecretAccessKey"],
+        "aws_session_token": response["Credentials"]["SessionToken"],
+    }
+
+
+def s3_object_is_accessible(bucket: str, key: str):
+    """
+    Ensure we can send HEAD requests to S3 objects.
+    """
+    client = boto3.client("s3", **get_s3_credentials())
+    try:
+        client.head_object(Bucket=bucket, Key=key)
+    except client.exceptions.ClientError as e:
+        raise ValueError(
+            f"Asset not accessible: {e.__dict__['response']['Error']['Message']}"
+        )
+
+
+@functools.lru_cache
+def s3_bucket_object_is_accessible(
+    bucket: str, prefix: str, zarr_store: Union[str, None] = None
+):
+    """
+    Ensure we can send HEAD requests to S3 objects in bucket.
+    """
+    client = boto3.client("s3", **get_s3_credentials())
+    prefix = f"{prefix}{zarr_store}" if zarr_store else prefix
+    try:
+        result = client.list_objects(Bucket=bucket, Prefix=prefix, MaxKeys=2)
+    except client.exceptions.NoSuchBucket:
+        raise ValueError("Bucket doesn't exist.")
+    except client.exceptions.ClientError as e:
+        raise ValueError(f"Access denied: {e.__dict__['response']['Error']['Message']}")
+    content = result.get("Contents", [])
+    if len(content) < 1:
+        raise ValueError("No data in bucket/prefix.")
+    try:
+        client.head_object(Bucket=bucket, Key=content[0].get("Key"))
+    except client.exceptions.ClientError as e:
+        raise ValueError(
+            f"Asset not accessible: {e.__dict__['response']['Error']['Message']}"
+        )
+
+
+def url_is_accessible(href: str):
+    """
+    Ensure URLs are accessible via HEAD requests.
+    """
+    try:
+        requests.head(href).raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        raise ValueError(
+            f"Asset not accessible: {e.response.status_code} {e.response.reason}"
+        )
+
+
+@functools.lru_cache()
+def collection_exists(collection_id: str) -> bool:
+    """
+    Ensure collection exists in STAC
+    """
+    from src.main import settings
+
+    url = "/".join(
+        f'{url.strip("/")}' for url in [settings.stac_url, "collections", collection_id]
+    )
+
+    if (response := requests.get(url)).ok:
+        return True
+
+    raise ValueError(
+        f"Invalid collection '{collection_id}', received "
+        f"{response.status_code} response code from STAC API"
+    )

--- a/ingest_api/runtime/src/vedaloader.py
+++ b/ingest_api/runtime/src/vedaloader.py
@@ -1,0 +1,54 @@
+"""Utilities to bulk load data into pgstac from json/ndjson."""
+import logging
+
+from pypgstac.load import Loader
+
+logger = logging.getLogger(__name__)
+
+
+class VEDALoader(Loader):
+    """Utilities for loading data and updating collection summaries/extents."""
+
+    def __init__(self, db) -> None:
+        super().__init__(db)
+        self.check_version()
+        self.conn = self.db.connect()
+
+    def update_collection_summaries(self, collection_id: str) -> None:
+        """Update collection-level summaries for a single collection.
+        This includes dashboard summaries (i.e. datetime and cog_default) as well as
+        STAC-conformant bbox and temporal extent."""
+        with self.conn.cursor() as cur:
+            with self.conn.transaction():
+                logger.info(
+                    f"Updating dashboard summaries for collection: {collection_id}."
+                )
+                cur.execute(
+                    "SELECT dashboard.update_collection_default_summaries(%s)",
+                    (collection_id,),
+                )
+                logger.info(f"Updating extents for collection: {collection_id}.")
+                cur.execute(
+                    """
+                    UPDATE collections SET
+                    content = content ||
+                    jsonb_build_object(
+                        'extent', jsonb_build_object(
+                            'spatial', jsonb_build_object(
+                                'bbox', collection_bbox(collections.id)
+                            ),
+                            'temporal', jsonb_build_object(
+                                'interval', collection_temporal_extent(collections.id)
+                            )
+                        )
+                    )
+                    WHERE collections.id=%s;
+                    """,
+                    (collection_id,),
+                )
+
+    def delete_collection(self, collection_id: str) -> None:
+        with self.conn.cursor() as cur:
+            with self.conn.transaction():
+                logger.info(f"Deleting collection: {collection_id}.")
+                cur.execute("SELECT pgstac.delete_collection(%s);", (collection_id,))

--- a/ingest_api/runtime/tests/conftest.py
+++ b/ingest_api/runtime/tests/conftest.py
@@ -1,0 +1,156 @@
+import os
+
+import boto3
+import pytest
+from moto import mock_dynamodb, mock_ssm
+from stac_pydantic import Item
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def test_environ():
+    # Mocked AWS Credentials for moto (best practice recommendation from moto)
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+    # Config mocks
+    os.environ["CLIENT_ID"] = "fake_client_id"
+    os.environ["CLIENT_SECRET"] = "fake_client_secret"
+    os.environ["DATA_ACCESS_ROLE_ARN"] = "arn:aws:iam::123456789012:role/test-role"
+    os.environ["DYNAMODB_TABLE"] = "test_table"
+    os.environ["JWKS_URL"] = "https://test-jwks.url"
+    os.environ["STAC_URL"] = "https://test-stac.url"
+    os.environ["RASTER_URL"] = "https://test-raster.url"
+    os.environ["USERPOOL_ID"] = "fake_id"
+
+
+@pytest.fixture
+def mock_ssm_parameter_store():
+    with mock_ssm():
+        yield boto3.client("ssm", region_name="us-west-2")
+
+
+@pytest.fixture
+def app(test_environ, mock_ssm_parameter_store):
+    from src.main import app
+
+    return app
+
+
+@pytest.fixture
+def api_client(app):
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_table(app, test_environ):
+    from src import dependencies, main
+
+    with mock_dynamodb():
+        client = boto3.resource("dynamodb")
+        mock_table = client.create_table(
+            TableName=main.settings.dynamodb_table,
+            AttributeDefinitions=[
+                {"AttributeName": "created_by", "AttributeType": "S"},
+                {"AttributeName": "id", "AttributeType": "S"},
+                {"AttributeName": "status", "AttributeType": "S"},
+                {"AttributeName": "created_at", "AttributeType": "S"},
+            ],
+            KeySchema=[
+                {"AttributeName": "created_by", "KeyType": "HASH"},
+                {"AttributeName": "id", "KeyType": "RANGE"},
+            ],
+            BillingMode="PAY_PER_REQUEST",
+            GlobalSecondaryIndexes=[
+                {
+                    "IndexName": "status",
+                    "KeySchema": [
+                        {"AttributeName": "status", "KeyType": "HASH"},
+                        {"AttributeName": "created_at", "KeyType": "RANGE"},
+                    ],
+                    "Projection": {"ProjectionType": "ALL"},
+                }
+            ],
+        )
+        app.dependency_overrides[dependencies.get_table] = lambda: mock_table
+        yield mock_table
+        app.dependency_overrides.pop(dependencies.get_table)
+
+
+@pytest.fixture
+def example_stac_item():
+    return {
+        "stac_version": "1.0.0",
+        "stac_extensions": [],
+        "type": "Feature",
+        "id": "20201211_223832_CS2",
+        "bbox": [
+            172.91173669923782,
+            1.3438851951615003,
+            172.95469614953714,
+            1.3690476620161975,
+        ],
+        "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [172.91173669923782, 1.3438851951615003],
+                    [172.95469614953714, 1.3438851951615003],
+                    [172.95469614953714, 1.3690476620161975],
+                    [172.91173669923782, 1.3690476620161975],
+                    [172.91173669923782, 1.3438851951615003],
+                ]
+            ],
+        },
+        "properties": {"datetime": "2020-12-11T22:38:32.125000Z"},
+        "collection": "simple-collection",
+        "links": [
+            {
+                "rel": "collection",
+                "href": "./collection.json",
+                "type": "application/json",
+                "title": "Simple Example Collection",
+            },
+            {
+                "rel": "root",
+                "href": "./collection.json",
+                "type": "application/json",
+                "title": "Simple Example Collection",
+            },
+            {
+                "rel": "parent",
+                "href": "./collection.json",
+                "type": "application/json",
+                "title": "Simple Example Collection",
+            },
+        ],
+        "assets": {
+            "visual": {
+                "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif",  # noqa
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "title": "3-Band Visual",
+                "roles": ["visual"],
+            },
+            "thumbnail": {
+                "href": "https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg",  # noqa
+                "title": "Thumbnail",
+                "type": "image/jpeg",
+                "roles": ["thumbnail"],
+            },
+        },
+    }
+
+
+@pytest.fixture
+def example_ingestion(example_stac_item):
+    from src import schemas
+
+    return schemas.Ingestion(
+        id=example_stac_item["id"],
+        created_by="test-user",
+        status=schemas.Status.queued,
+        item=Item.parse_obj(example_stac_item),
+    )

--- a/ingest_api/runtime/tests/test_registration.py
+++ b/ingest_api/runtime/tests/test_registration.py
@@ -1,0 +1,91 @@
+import base64
+import json
+from datetime import timedelta
+from math import isclose
+from typing import TYPE_CHECKING, List
+
+import pytest
+from src.schemas import Ingestion
+
+if TYPE_CHECKING:
+    from src import schemas, services
+
+    from fastapi.testclient import TestClient
+
+ingestion_endpoint = "/ingestions"
+
+
+class TestList:
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        api_client: "TestClient",
+        mock_table: "services.Table",
+        example_ingestion: "schemas.Ingestion",
+    ):
+        self.api_client = api_client
+        self.mock_table = mock_table
+        self.example_ingestion = example_ingestion
+
+    def populate_table(self, count=100) -> List["schemas.Ingestion"]:
+        example_ingestions = []
+        for i in range(count):
+            ingestion = self.example_ingestion.copy()
+            ingestion.id = str(i)
+            ingestion.created_at = ingestion.created_at + timedelta(hours=i)
+            self.mock_table.put_item(Item=ingestion.dynamodb_dict())
+            example_ingestions.append(ingestion)
+        return example_ingestions
+
+    def test_simple_lookup(self):
+        self.mock_table.put_item(Item=self.example_ingestion.dynamodb_dict())
+
+        response = self.api_client.get(ingestion_endpoint)
+        assert response.status_code == 200
+        assert response.json() == {
+            "items": [json.loads(self.example_ingestion.json(by_alias=True))],
+            "next": None,
+        }
+
+    def test_next_response(self):
+        example_ingestions = self.populate_table(100)
+
+        limit = 25
+        expected_next = json.loads(
+            example_ingestions[limit - 1].json(
+                include={"created_by", "id", "status", "created_at"}
+            )
+        )
+
+        response = self.api_client.get(ingestion_endpoint, params={"limit": limit})
+        assert response.status_code == 200
+        assert json.loads(base64.b64decode(response.json()["next"])) == expected_next
+        assert response.json()["items"] == [
+            json.loads(ingestion.json(by_alias=True))
+            for ingestion in example_ingestions[:limit]
+        ]
+
+    def test_load_large_number(self):
+        ingestion_data = self.example_ingestion.dict()
+        visual_asset = ingestion_data["item"]["assets"]["visual"]
+        # todo: why does this need to be a float?
+        visual_asset["nodata"] = -3.4028234663852886e38
+        ingestion = Ingestion.parse_obj(ingestion_data)
+        self.mock_table.put_item(Item=ingestion.dynamodb_dict())
+
+        response = self.api_client.get(ingestion_endpoint)
+        actual = response.json()["items"]
+        expected = [json.loads(ingestion.json(by_alias=True))]
+
+        # first, check the nodata value
+        # value should match, format will not. isclose() will properly compare the values
+        assert isclose(
+            actual[0]["item"]["assets"]["visual"]["nodata"],
+            expected[0]["item"]["assets"]["visual"]["nodata"],
+            abs_tol=1,
+        )
+        expected[0]["item"]["assets"]["visual"]["nodata"] = actual[0]["item"]["assets"][
+            "visual"
+        ]["nodata"]
+        # second, check everything else
+        assert actual == expected

--- a/local/Dockerfile.ingest
+++ b/local/Dockerfile.ingest
@@ -1,0 +1,22 @@
+FROM public.ecr.aws/sam/build-python3.9:latest
+
+WORKDIR /tmp
+
+COPY ingest_api/runtime /tmp/ingestor
+RUN pip install -r /tmp/ingestor/requirements.txt -t /asset --no-binary pydantic uvicorn
+RUN rm -rf /tmp/ingestor
+# TODO this is temporary until we use a real packaging system like setup.py or poetry
+COPY ingest_api/runtime/src /asset/src
+
+# # Reduce package size and remove useless files
+RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;
+RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+#RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
+
+COPY ingest_api/runtime/handler.py /asset/handler.py
+COPY ingest_api/runtime/ingestor.py /asset/ingestor.py
+COPY ingest_api/runtime/local.py /asset/local.py
+
+CMD ["python" "/asset/local.py"]

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -54,7 +54,7 @@ class vedaRasterSettings(BaseSettings):
         description="Name or ARN of the AWS Secret containing database connection parameters",
     )
 
-    raster_data_access_role_arn: Optional[str] = Field(
+    data_access_role_arn: Optional[str] = Field(
         None,
         description="Resource name of role permitting access to specified external S3 buckets",
     )

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -54,7 +54,7 @@ class vedaRasterSettings(BaseSettings):
         description="Name or ARN of the AWS Secret containing database connection parameters",
     )
 
-    data_access_role_arn: Optional[str] = Field(
+    raster_data_access_role_arn: Optional[str] = Field(
         None,
         description="Resource name of role permitting access to specified external S3 buckets",
     )

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -131,12 +131,12 @@ class RasterApiLambdaConstruct(Construct):
         )
 
         # Optional use sts assume role with GetObject permissions for external S3 bucket(s)
-        if veda_raster_settings.raster_data_access_role_arn:
+        if veda_raster_settings.data_access_role_arn:
             # Get the role for external data access
             data_access_role = aws_iam.Role.from_role_arn(
                 self,
                 "data-access-role",
-                veda_raster_settings.raster_data_access_role_arn,
+                veda_raster_settings.data_access_role_arn,
             )
 
             # Allow this lambda to assume the data access role
@@ -147,7 +147,7 @@ class RasterApiLambdaConstruct(Construct):
 
             veda_raster_function.add_environment(
                 "VEDA_RASTER_DATA_ACCESS_ROLE_ARN",
-                veda_raster_settings.raster_data_access_role_arn,
+                veda_raster_settings.data_access_role_arn,
             )
 
         # Optional configuration to export assume role session into lambda function environment

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -23,7 +23,7 @@ if typing.TYPE_CHECKING:
 
 
 class RasterApiLambdaConstruct(Construct):
-    """CDK Constrcut for a Lambda based TiTiler API with pgstac extension."""
+    """CDK Construct for a Lambda based TiTiler API with pgstac extension."""
 
     def __init__(
         self,

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -131,12 +131,12 @@ class RasterApiLambdaConstruct(Construct):
         )
 
         # Optional use sts assume role with GetObject permissions for external S3 bucket(s)
-        if veda_raster_settings.data_access_role_arn:
+        if veda_raster_settings.raster_data_access_role_arn:
             # Get the role for external data access
             data_access_role = aws_iam.Role.from_role_arn(
                 self,
                 "data-access-role",
-                veda_raster_settings.data_access_role_arn,
+                veda_raster_settings.raster_data_access_role_arn,
             )
 
             # Allow this lambda to assume the data access role
@@ -147,7 +147,7 @@ class RasterApiLambdaConstruct(Construct):
 
             veda_raster_function.add_environment(
                 "VEDA_RASTER_DATA_ACCESS_ROLE_ARN",
-                veda_raster_settings.data_access_role_arn,
+                veda_raster_settings.raster_data_access_role_arn,
             )
 
         # Optional configuration to export assume role session into lambda function environment

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -30,7 +30,7 @@ class LoggerRouteHandler(APIRoute):
             logger.info("Received request")
             metrics.add_metric(
                 name="/".join(
-                    str(request.url).split("/")[:2]
+                    str(request.url.path).split("/")[:2]
                 ),  # enough detail to capture search IDs, but not individual tile coords
                 unit=MetricUnit.Count,
                 value=1,

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -3,6 +3,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 from aws_cdk import CfnOutput, Stack
+from aws_cdk import aws_apigateway as apigateway
 from aws_cdk import aws_certificatemanager as certificatemanager
 from aws_cdk import aws_cloudfront as cf
 from aws_cdk import aws_cloudfront_origins as origins
@@ -79,33 +80,14 @@ class CloudfrontDistributionConstruct(Construct):
                         allowed_methods=cf.AllowedMethods.ALLOW_ALL,
                         origin_request_policy=cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
                     ),
-                    "/api/ingest*": cf.BehaviorOptions(
-                        origin=origins.HttpOrigin(
-                            urlparse(veda_route_settings.ingest_url).hostname,
-                            origin_id="ingest-api",
-                            origin_path=f"/{stage}",
-                        ),
-                        cache_policy=cf.CachePolicy.CACHING_DISABLED,
-                        allowed_methods=cf.AllowedMethods.ALLOW_ALL,
-                    ),
                 },
             )
 
-            hosted_zone = aws_route53.HostedZone.from_hosted_zone_attributes(
+            self.hosted_zone = aws_route53.HostedZone.from_hosted_zone_attributes(
                 self,
                 "hosted-zone",
                 hosted_zone_id=veda_route_settings.domain_hosted_zone_id,
                 zone_name=veda_route_settings.domain_hosted_zone_name,
-            )
-
-            aws_route53.ARecord(
-                self,
-                "cloudfront-dns-record",
-                zone=hosted_zone,
-                target=aws_route53.RecordTarget.from_alias(
-                    aws_route53_targets.CloudFrontTarget(self.distribution)
-                ),
-                record_name=stage,
             )
 
             # Infer cloudfront arn to add to bucket resource policy
@@ -124,3 +106,35 @@ class CloudfrontDistributionConstruct(Construct):
             )
 
             CfnOutput(self, "Endpoint", value=self.distribution.domain_name)
+
+    # required as second step as ingest API depends on stac API route
+    def add_ingest_behavior(
+        self,
+        ingest_api,
+        stage: str,
+        region: Optional[str] = "us-west-2",
+    ):
+        if veda_route_settings.cloudfront:
+            self.distribution.add_behavior(
+                "/api/ingest*",
+                origin=origins.HttpOrigin(
+                    f"{ingest_api.api_id}.execute-api.{region}.amazonaws.com",
+                    origin_id="ingest-api",
+                ),
+                cache_policy=cf.CachePolicy.CACHING_DISABLED,
+                allowed_methods=cf.AllowedMethods.ALLOW_ALL,
+                origin_request_policy=cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+            )
+
+    # this is a seperate function so that it can be called after all behaviors are instantiated
+    def create_route_records(self, stage: str):
+        if veda_route_settings.cloudfront:
+            aws_route53.ARecord(
+                self,
+                "cloudfront-dns-record",
+                zone=self.hosted_zone,
+                target=aws_route53.RecordTarget.from_alias(
+                    aws_route53_targets.CloudFrontTarget(self.distribution)
+                ),
+                record_name=stage,
+            )

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -1,9 +1,7 @@
 """CDK Construct for a Cloudfront Distribution."""
 from typing import Optional
-from urllib.parse import urlparse
 
 from aws_cdk import CfnOutput, Stack
-from aws_cdk import aws_apigateway as apigateway
 from aws_cdk import aws_certificatemanager as certificatemanager
 from aws_cdk import aws_cloudfront as cf
 from aws_cdk import aws_cloudfront_origins as origins
@@ -107,13 +105,13 @@ class CloudfrontDistributionConstruct(Construct):
 
             CfnOutput(self, "Endpoint", value=self.distribution.domain_name)
 
-    # required as second step as ingest API depends on stac API route
     def add_ingest_behavior(
         self,
         ingest_api,
         stage: str,
         region: Optional[str] = "us-west-2",
     ):
+        """Required as second step as ingest API depends on stac API route"""
         if veda_route_settings.cloudfront:
             self.distribution.add_behavior(
                 "/api/ingest*",
@@ -126,8 +124,8 @@ class CloudfrontDistributionConstruct(Construct):
                 origin_request_policy=cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             )
 
-    # this is a seperate function so that it can be called after all behaviors are instantiated
     def create_route_records(self, stage: str):
+        """This is a seperate function so that it can be called after all behaviors are instantiated"""
         if veda_route_settings.cloudfront:
             aws_route53.ARecord(
                 self,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,4 +20,4 @@ explicit_package_bases = True
 
 [pydocstyle]
 select = D1
-match = (?!test).*\.py
+match = (?!test|ingest_api).*\.py

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ extra_reqs = {
         "httpx==0.23.3",
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
+        "fastapi",
+        "moto",
     ],
 }
 


### PR DESCRIPTION
Revives and closes #172 

## Why

While working through our production goals (https://github.com/NASA-IMPACT/veda-architecture/issues/332), we found that managing multiple repositories for our backend services wasn't doing us many favors for maintainability. A relevant [ADR ](https://github.com/NASA-IMPACT/veda-architecture/pull/351/files)was made for `veda-features-api`, and many of the arguments for consolidating repositories also applies to `veda-stac-ingestor`

## What

Since #174, we've done significant work refactoring this repo, and have added several infrastructure changes that needed to be accommodated, including new routing mechanisms and Cloudfront support. To maintain consistency, I also had to refactor parts of the ingest API to align with how our other services are provisioned.

## How to review

With very few exceptions (configuration changes + root path support), the runtime code has not changed from `veda-stac-ingestor`. I would suggest mostly [ignoring ](https://github.com/NASA-IMPACT/veda-backend/pull/258/files/d664660cff44d66c689ee5314b47e324bf13a028..4c6e4b4e8b36e886be3abb9315652355fd6e6b3a)this commit when reviewing - it shrinks the number of files in the PR in half.