### PR TITLE
fix: raster endpoint url fix for render links

### DIFF
--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -71,7 +71,7 @@ class StacApiLambdaConstruct(Construct):
         )
 
         if veda_stac_settings.custom_host:
-            titler_endpoint = f"https://{veda_stac_settings.custom_host}{veda_stac_settings.raster_root_path}"
+            titler_endpoint = f"https://{veda_stac_settings.custom_host}{veda_stac_settings.raster_root_path}/"
         else:
             titler_endpoint = raster_api.raster_api.url
         lambda_function.add_environment("TITILER_ENDPOINT", titler_endpoint)


### PR DESCRIPTION
Include trailing slash in raster endpoint