### PR TITLE
fix(ingest): use defaults for auth env configuration

### DIFF
--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -34,7 +34,7 @@ class IngestorConfig(BaseSettings):
     userpool_id: str = Field(description="The Cognito Userpool used for authentication")
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: Optional[str] = Field(
-        None, description="The Cognito APP client secret"
+        "", description="The Cognito APP client secret"
     )
 
     stac_db_secret_name: str = Field(

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -65,6 +65,7 @@ class IngestorConfig(BaseSettings):
     class Config:
         case_sensitive = False
         env_file = ".env"
+        env_prefix = "VEDA_"
 
     @property
     def stack_name(self) -> str:

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -33,7 +33,9 @@ class IngestorConfig(BaseSettings):
 
     userpool_id: str = Field(description="The Cognito Userpool used for authentication")
     client_id: str = Field(description="The Cognito APP client ID")
-    client_secret: str = Field(description="The Cognito APP client secret")
+    client_secret: Optional[str] = Field(
+        None, description="The Cognito APP client secret"
+    )
 
     stac_db_secret_name: str = Field(
         description="Name of secret containing pgSTAC DB connection information"
@@ -63,7 +65,6 @@ class IngestorConfig(BaseSettings):
     class Config:
         case_sensitive = False
         env_file = ".env"
-        env_prefix = "VEDA_"
 
     @property
     def stack_name(self) -> str:

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -1,4 +1,4 @@
-from pydantic import AnyHttpUrl, BaseSettings, Field, constr
+from pydantic import AnyHttpUrl, BaseSettings, Field, Optional, constr
 from pydantic_ssm_settings import AwsSsmSourceConfig
 
 AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
@@ -19,7 +19,9 @@ class Settings(BaseSettings):
     userpool_id: str = Field(description="The Cognito Userpool used for authentication")
 
     client_id: str = Field(description="The Cognito APP client ID")
-    client_secret: str = Field(description="The Cognito APP client secret")
+    client_secret: Optional[str] = Field(
+        None, description="The Cognito APP client secret"
+    )
     root_path: str = Field(description="Root path of API")
     stage: str = Field(description="API stage")
 

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -1,4 +1,4 @@
-from pydantic import AnyHttpUrl, BaseSettings, Field, Optional, constr
+from pydantic import AnyHttpUrl, BaseSettings, Field, constr
 from pydantic_ssm_settings import AwsSsmSourceConfig
 
 AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
@@ -19,9 +19,7 @@ class Settings(BaseSettings):
     userpool_id: str = Field(description="The Cognito Userpool used for authentication")
 
     client_id: str = Field(description="The Cognito APP client ID")
-    client_secret: Optional[str] = Field(
-        None, description="The Cognito APP client secret"
-    )
+    client_secret: str = Field("", description="The Cognito APP client secret")
     root_path: str = Field(description="Root path of API")
     stage: str = Field(description="API stage")
 

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -8,13 +8,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 from urllib.parse import urlparse
 
 import src.validators as validators
-from pydantic import (
-    BaseModel,
-    Field,
-    PositiveInt,
-    error_wrappers,
-    validator,
-)
+from pydantic import BaseModel, Field, PositiveInt, error_wrappers, validator
 from src.schema_helpers import SpatioTemporalExtent
 from stac_pydantic import Collection, Item, shared
 from stac_pydantic.links import Link

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -63,10 +63,10 @@ class DashboardCollection(Collection):
     class Config:
         allow_population_by_field_name = True
 
-    @root_validator
-    def check_time_density(cls, values):
-        validators.time_density_is_valid(values["is_periodic"], values["time_density"])
-        return values
+    # @root_validator
+    # def check_time_density(cls, values):
+    #     validators.time_density_is_valid(values["is_periodic"], values["time_density"])
+    #     return values
 
 
 class Status(str, enum.Enum):

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -63,10 +63,10 @@ class DashboardCollection(Collection):
     class Config:
         allow_population_by_field_name = True
 
-    # @root_validator
-    # def check_time_density(cls, values):
-    #     validators.time_density_is_valid(values["is_periodic"], values["time_density"])
-    #     return values
+    @root_validator
+    def check_time_density(cls, values):
+        validators.time_density_is_valid(values["is_periodic"], values["time_density"])
+        return values
 
 
 class Status(str, enum.Enum):

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -13,7 +13,6 @@ from pydantic import (
     Field,
     PositiveInt,
     error_wrappers,
-    root_validator,
     validator,
 )
 from src.schema_helpers import SpatioTemporalExtent
@@ -62,11 +61,6 @@ class DashboardCollection(Collection):
 
     class Config:
         allow_population_by_field_name = True
-
-    @root_validator
-    def check_time_density(cls, values):
-        validators.time_density_is_valid(values["is_periodic"], values["time_density"])
-        return values
 
 
 class Status(str, enum.Enum):

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -102,9 +102,9 @@ class AuthResponse(BaseModel):
 
 class WhoAmIResponse(BaseModel):
     sub: str = Field(..., description="A unique identifier for the user")
-    cognito_groups: List[str] = Field(
-        ..., description="A list of Cognito groups the user belongs to"
-    )
+    # cognito_groups: List[str] = Field(
+    #     ..., description="A list of Cognito groups the user belongs to"
+    # )
     iss: str = Field(..., description="The issuer of the token")
     client_id: str = Field(..., description="The client ID of the authenticated app")
     origin_jti: str = Field(

--- a/ingest_api/runtime/src/validators.py
+++ b/ingest_api/runtime/src/validators.py
@@ -91,3 +91,15 @@ def collection_exists(collection_id: str) -> bool:
         f"Invalid collection '{collection_id}', received "
         f"{response.status_code} response code from STAC API"
     )
+
+
+def time_density_is_valid(is_periodic: bool, time_density: Union[str, None]):
+    """
+    Ensures that the time_density is valid based on the value of is_periodic
+    """
+    if is_periodic and not time_density:
+        raise ValueError("If is_periodic is true, time_density must be set.")
+
+    # Literal[str, None] doesn't quite work for null field inputs from a dict()
+    if time_density and time_density not in ["day", "month", "year"]:
+        raise ValueError("If set, time_density must be one of 'day, 'month' or 'year'")

--- a/ingest_api/runtime/src/validators.py
+++ b/ingest_api/runtime/src/validators.py
@@ -91,15 +91,3 @@ def collection_exists(collection_id: str) -> bool:
         f"Invalid collection '{collection_id}', received "
         f"{response.status_code} response code from STAC API"
     )
-
-
-def time_density_is_valid(is_periodic: bool, time_density: Union[str, None]):
-    """
-    Ensures that the time_density is valid based on the value of is_periodic
-    """
-    if is_periodic and not time_density:
-        raise ValueError("If is_periodic is true, time_density must be set.")
-
-    # Literal[str, None] doesn't quite work for null field inputs from a dict()
-    if time_density and time_density not in ["day", "month", "year"]:
-        raise ValueError("If set, time_density must be one of 'day, 'month' or 'year'")


### PR DESCRIPTION
# What
Minor fixes in ingest API to support cognito clients not configured with secrets. Tested end to end token generation, validation, and collection publication in externally deployed instance.
