### PR TITLE
fix: add debugging to authenticate_and_get_token()

### DIFF
--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -111,4 +111,6 @@ def authenticate_and_get_token(
         }
     except Exception as e:
         return {"message": f"Login failed with exception {e}"}
+    except TimeoutError as te:
+        return {"message:" f"Request timed out: {te}"}
     return resp["AuthenticationResult"]


### PR DESCRIPTION
What:
- Added TimeOut check for debugging purposes

Why:
- dev `/token` endpoint times out