### PR TITLE
fix: update ingest api subnet types and log format and update pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,8 @@ repos:
         language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v1.2.0
     hooks:
       - id: mypy
         language_version: python
+        additional_dependencies: ['types-requests', 'types-cachetools']

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -135,6 +135,10 @@ class ApiConstruct(Construct):
                 )
             ],
         )
+
+        subnets = ec2.SubnetSelection(
+            subnet_type=ec2.SubnetType.PRIVATE_ISOLATED
+        ).subnets
         handler = aws_lambda.Function(
             self,
             "api-handler",
@@ -149,13 +153,10 @@ class ApiConstruct(Construct):
             role=handler_role,
             environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
             vpc=db_vpc,
-            vpc_subnets=ec2.SubnetSelection(
-                subnet_type=ec2.SubnetType.PUBLIC
-                if db_subnet_public
-                else ec2.SubnetType.PRIVATE_ISOLATED
-            ),
+            vpc_subnets=subnets,
             allow_public_subnet=True,
             memory_size=2048,
+            log_format="JSON",
         )
         table.grant_read_write_data(handler)
         data_access_role.grant(


### PR DESCRIPTION
## Description
- This PR updates the subnet type for the ingest api handler to use private subnets.
- This PR also updates the pre-commit yaml file

## Related Issues
https://github.com/NASA-IMPACT/veda-backend/issues/280

## Changes Made
- Update ingest api to use private subnets
- Update `pre-commit-config.yaml` to update `mypy` rev and add `additional_dependencies`

## Testing Done
I manually update the dev ingest api lambda to have private subnets (previously, they were configured with public subnets) and tested the dev delta `/token` endpoint and the lambda endpoint itself.