### PR TITLE
Add workflow API

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from domain.infrastructure.construct import DomainConstruct
 from ingest_api.infrastructure.config import IngestorConfig as ingest_config
 from ingest_api.infrastructure.construct import ApiConstruct as ingest_api_construct
 from ingest_api.infrastructure.construct import IngestorConstruct as ingestor_construct
+from workflow_api.infrastructure.construct import ApiConstruct as workflow_api_construct
 from network.infrastructure.construct import VpcConstruct
 from permissions_boundary.infrastructure.construct import PermissionsBoundaryAspect
 from raster_api.infrastructure.construct import RasterApiLambdaConstruct
@@ -147,6 +148,13 @@ ingestor = ingestor_construct(
 
 veda_routes.add_ingest_behavior(
     ingest_api=ingest_api.api, stage=veda_app_settings.stage_name()
+)
+
+workflow_api = workflow_api_construct(
+    veda_stack,
+    "workflow-api",
+    config=None,
+    domain=domain,
 )
 
 # Must be done after all CF behaviors exist

--- a/app.py
+++ b/app.py
@@ -18,8 +18,6 @@ from raster_api.infrastructure.construct import RasterApiLambdaConstruct
 from routes.infrastructure.construct import CloudfrontDistributionConstruct
 from s3_website.infrastructure.construct import VedaWebsite
 from stac_api.infrastructure.construct import StacApiLambdaConstruct
-from workflow_api.infrastructure.config import WorkflowConfig as workflow_config
-from workflow_api.infrastructure.construct import ApiConstruct as workflow_api_construct
 
 from eoapi_cdk import StacBrowser
 
@@ -126,6 +124,7 @@ ingestor_config = ingest_config(
     stac_db_public_subnet=database.is_publicly_accessible,
     stac_api_url=stac_api.stac_api.url,
     raster_api_url=raster_api.raster_api.url,
+    mwaa_env=veda_app_settings.mwaa_env,
 )
 
 
@@ -149,22 +148,6 @@ ingestor = ingestor_construct(
 
 veda_routes.add_ingest_behavior(
     ingest_api=ingest_api.api, stage=veda_app_settings.stage_name()
-)
-
-workflow_api_config = workflow_config(
-    stac_db_vpc_id=vpc.vpc.vpc_id,
-    stac_db_secret_name=db_secret_name,
-    stac_db_security_group_id=db_security_group.security_group_id,
-    stac_db_public_subnet=database.is_publicly_accessible,
-    mwaa_env=veda_app_settings.mwaa_env,
-)
-
-workflow_api = workflow_api_construct(
-    veda_stack,
-    "workflow-api",
-    config=workflow_api_config,
-    domain=domain,
-    db_vpc=vpc.vpc,
 )
 
 # Must be done after all CF behaviors exist

--- a/config.py
+++ b/config.py
@@ -102,6 +102,10 @@ class vedaAppSettings(BaseSettings):
         None, description="Custom domain name, i.e. veda-backend.xyz"
     )
 
+    mwaa_env: Optional[str] = Field(
+        None, description="Optional name of MWAA environment to be used by workflow API"
+    )
+
     def cdk_env(self) -> dict:
         """Load a cdk environment dict for stack"""
 

--- a/domain/infrastructure/construct.py
+++ b/domain/infrastructure/construct.py
@@ -30,6 +30,7 @@ class DomainConstruct(Construct):
         self.stac_domain_name = None
         self.raster_domain_name = None
         self.ingest_domain_name = None
+        self.workflow_domain_name = None
 
         if veda_domain_settings.create_custom_subdomains:
             # If alternative custom domain provided, use it instead of the default

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -62,6 +62,14 @@ class IngestorConfig(BaseSettings):
     ingest_root_path: str = Field(description="Root path for ingest API")
     custom_host: Optional[str] = Field(description="Custom host name")
 
+    # Workflow sub-app settings
+
+    mwaa_env: Optional[str] = Field(
+        description="Environment of Airflow deployment",
+    )
+
+    workflow_root_path: Optional[str] = Field("/", description="Workflow API root path")
+
     class Config:
         case_sensitive = False
         env_file = ".env"

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -59,8 +59,9 @@ class ApiConstruct(Construct):
             "CLIENT_ID": config.client_id,
             "CLIENT_SECRET": config.client_secret,
             "RASTER_URL": config.raster_api_url,
-            "ROOT_PATH": config.ingest_root_path,
+            "INGEST_ROOT_PATH": config.ingest_root_path,
             "STAGE": config.stage,
+            "WORKFLOW_ROOT_PATH": "/api/workflows",
         }
 
         # create lambda

--- a/ingest_api/runtime/handler.py
+++ b/ingest_api/runtime/handler.py
@@ -5,4 +5,4 @@ Entrypoint for Lambda execution.
 from mangum import Mangum
 from src.main import app
 
-handler = Mangum(app, lifespan="off", api_gateway_base_path=app.root_path)
+handler = Mangum(app, lifespan="off")

--- a/ingest_api/runtime/src/airflow_helpers.py
+++ b/ingest_api/runtime/src/airflow_helpers.py
@@ -1,0 +1,160 @@
+import base64
+import os
+from typing import Dict
+from uuid import uuid4
+
+import boto3
+import requests
+from fastapi import HTTPException
+
+try:
+    from src.schemas import WorkflowExecutionResponse, Status
+except ImportError:
+    from src.schemas import WorkflowExecutionResponse, Status
+
+
+def cli_input(cli_string: str) -> Dict:
+    """
+    Pass a command directly to the CLI. Requires auth.
+    """
+    if not (MWAA_ENV := os.environ.get("MWAA_ENV")):
+        raise HTTPException(status_code=400, detail="MWAA environment not set")
+
+    airflow_client = boto3.client("mwaa")
+    mwaa_cli_token = airflow_client.create_cli_token(Name=MWAA_ENV)
+
+    mwaa_webserver_hostname = (
+        f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
+    )
+
+    mwaa_response = requests.post(
+        mwaa_webserver_hostname,
+        headers={
+            "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
+            "Content-Type": "application/json",
+        },
+        data=cli_string,
+    )
+    if mwaa_response.raise_for_status():
+        raise Exception(
+            f"Failed to trigger airflow: {mwaa_response.status_code} "
+            f"{mwaa_response.text}"
+        )
+    else:
+        return WorkflowExecutionResponse(**mwaa_response)
+
+
+def trigger_discover(input: Dict) -> Dict:
+    if not (MWAA_ENV := os.environ.get("MWAA_ENV")):
+        raise HTTPException(status_code=400, detail="MWAA environment not set")
+
+    airflow_client = boto3.client("mwaa")
+    mwaa_cli_token = airflow_client.create_cli_token(Name=MWAA_ENV)
+
+    mwaa_webserver_hostname = (
+        f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
+    )
+
+    unique_key = str(uuid4())
+    raw_data = f"dags trigger veda_discover --conf '{input.json()}' -r {unique_key}"
+    mwaa_response = requests.post(
+        mwaa_webserver_hostname,
+        headers={
+            "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
+            "Content-Type": "application/json",
+        },
+        data=raw_data,
+    )
+    if mwaa_response.raise_for_status():
+        raise Exception(
+            f"Failed to trigger airflow: {mwaa_response.status_code} "
+            f"{mwaa_response.text}"
+        )
+    else:
+        return WorkflowExecutionResponse(
+            **{
+                "id": unique_key,
+                "status": Status.started,
+            }
+        )
+
+
+def list_dags() -> str:
+    if not (MWAA_ENV := os.environ.get("MWAA_ENV")):
+        raise HTTPException(status_code=400, detail="MWAA environment not set")
+
+    airflow_client = boto3.client("mwaa")
+    mwaa_cli_token = airflow_client.create_cli_token(Name=MWAA_ENV)
+
+    mwaa_webserver_hostname = (
+        f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
+    )
+
+    raw_data = f"dags list"
+    mwaa_response = requests.post(
+        mwaa_webserver_hostname,
+        headers={
+            "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
+            "Content-Type": "application/json",
+        },
+        data=raw_data,
+    )
+    if mwaa_response.raise_for_status():
+        raise Exception(
+            f"Failed to trigger airflow: {mwaa_response.status_code} "
+            f"{mwaa_response.text}"
+        )
+    else:
+        return mwaa_response.text
+
+
+def get_status(dag_run_id: str) -> Dict:
+    """
+    Get the status of a workflow execution.
+    """
+    if not (MWAA_ENV := os.environ.get("MWAA_ENV")):
+        raise HTTPException(status_code=400, detail="MWAA environment not set")
+
+    airflow_client = boto3.client("mwaa")
+    mwaa_cli_token = airflow_client.create_cli_token(Name=MWAA_ENV)
+
+    mwaa_webserver_hostname = (
+        f"https://{mwaa_cli_token['WebServerHostname']}/aws_mwaa/cli"
+    )
+
+    raw_data = "dags list-runs -d veda_discover"
+    mwaa_response = requests.post(
+        mwaa_webserver_hostname,
+        headers={
+            "Authorization": "Bearer " + mwaa_cli_token["CliToken"],
+            "Content-Type": "application/json",
+        },
+        data=raw_data,
+    )
+    decoded_response = base64.b64decode(mwaa_response.json()["stdout"]).decode("utf8")
+    rows = decoded_response.split("\n")
+
+    try:
+        matched_row = next(row for row in rows if dag_run_id in row)
+    except StopIteration:
+        raise Exception(f"Failed to find dag run id: {dag_run_id}")
+
+    columns = matched_row.split("|")
+    status = columns[2].strip()
+
+    # Statuses in Airflow differ slightly from our own, so we convert them here
+    if status == "success":
+        run_status = Status.succeeded
+    elif status == "failed":
+        run_status = Status.failed
+    elif status == "running":
+        run_status = Status.started
+    elif status == "queued":
+        run_status = Status.queued
+
+    return WorkflowExecutionResponse(
+        **{
+            "id": dag_run_id,
+            "status": run_status,
+        }
+    )

--- a/ingest_api/runtime/src/collection_publisher.py
+++ b/ingest_api/runtime/src/collection_publisher.py
@@ -1,13 +1,25 @@
 import os
+from typing import Optional, Union
 
+import fsspec
+import xarray as xr
+import xstac
 from pypgstac.db import PgstacDB
-from src.schemas import DashboardCollection
+from src.schemas import (
+    COGDataset,
+    DashboardCollection,
+    DataType,
+    SpatioTemporalExtent,
+    ZarrDataset,
+)
 from src.utils import (
+    DbCreds,
     IngestionType,
     convert_decimals_to_float,
     get_db_credentials,
     load_into_pgstac,
 )
+from src.validators import get_s3_credentials
 from src.vedaloader import VEDALoader
 from stac_pydantic import Item
 
@@ -47,3 +59,154 @@ class ItemPublisher:
         item = [convert_decimals_to_float(item.dict(by_alias=True))]
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             load_into_pgstac(db=db, ingestions=item, table=IngestionType.items)
+
+
+# TODO refactor
+class Publisher:
+    common_fields = [
+        "title",
+        "description",
+        "license",
+        "links",
+        "time_density",
+        "is_periodic",
+    ]
+    common = {
+        "links": [],
+        "extent": {
+            "spatial": {"bbox": [[-180, -90, 180, 90]]},
+            "temporal": {"interval": [[None, None]]},
+        },
+        "type": "Collection",
+        "stac_version": "1.0.0",
+    }
+    db_creds: Optional[DbCreds]
+
+    def __init__(self, db_creds: Optional[DbCreds] = None) -> None:
+        self.db_creds = db_creds
+        self.func_map = {
+            DataType.zarr: self.create_zarr_collection,
+            DataType.cog: self.create_cog_collection,
+        }
+
+    def get_template(self, dataset: Union[ZarrDataset, COGDataset]) -> dict:
+        dataset_dict = dataset.dict()
+        collection_dict = {
+            "id": dataset_dict["collection"],
+            **Publisher.common,
+            **{
+                key: dataset_dict[key]
+                for key in Publisher.common_fields
+                if key in dataset_dict.keys()
+            },
+        }
+        return collection_dict
+
+    def _create_zarr_template(self, dataset: ZarrDataset, store_path: str) -> dict:
+        template = self.get_template(dataset)
+        template["assets"] = {
+            "zarr": {
+                "href": store_path,
+                "title": "Zarr Array Store",
+                "description": "Zarr array store with one or several arrays (variables)",
+                "roles": ["data", "zarr"],
+                "type": "application/vnd+zarr",
+                "xarray:open_kwargs": {
+                    "engine": "zarr",
+                    "chunks": {},
+                    **dataset.xarray_kwargs,
+                },
+            }
+        }
+        return template
+
+    def create_zarr_collection(self, dataset: ZarrDataset) -> dict:
+        """
+        Creates a zarr stac collection based off of the user input
+        """
+        s3_creds = get_s3_credentials()
+        discovery = dataset.discovery_items[0]
+        store_path = f"s3://{discovery.bucket}/{discovery.prefix}{discovery.zarr_store}"
+        template = self._create_zarr_template(dataset, store_path)
+        store = fsspec.get_mapper(store_path, client_kwargs=s3_creds)
+        ds = xr.open_zarr(
+            store, consolidated=bool(dataset.xarray_kwargs.get("consolidated"))
+        )
+
+        collection = xstac.xarray_to_stac(
+            ds,
+            template,
+            temporal_dimension=dataset.temporal_dimension or "time",
+            x_dimension=dataset.x_dimension or "lon",
+            y_dimension=dataset.y_dimension or "lat",
+            reference_system=dataset.reference_system or 4326,
+        )
+        return collection.to_dict()
+
+    def create_cog_collection(self, dataset: COGDataset) -> dict:
+        collection_stac = self.get_template(dataset)
+        collection_stac["extent"] = SpatioTemporalExtent.parse_obj(
+            {
+                "spatial": {
+                    "bbox": [
+                        list(dataset.spatial_extent.dict(exclude_unset=True).values())
+                    ]
+                },
+                "temporal": {
+                    "interval": [
+                        # most of our data uses the Z suffix for UTC - isoformat() doesn't
+                        [
+                            x.isoformat().replace("+00:00", "Z")
+                            for x in list(
+                                dataset.temporal_extent.dict(
+                                    exclude_unset=True
+                                ).values()
+                            )
+                        ]
+                    ]
+                },
+            }
+        )
+        collection_stac["item_assets"] = {
+            "cog_default": {
+                "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+                "roles": ["data", "layer"],
+                "title": "Default COG Layer",
+                "description": "Cloud optimized default layer to display on map",
+            }
+        }
+        return collection_stac
+
+    def generate_stac(
+        self, dataset: Union[COGDataset, ZarrDataset], data_type: str
+    ) -> dict:
+        create_function = self.func_map.get(data_type, self.create_cog_collection)
+        return create_function(dataset)
+
+    def ingest(self, collection: DashboardCollection):
+        """
+        Takes a collection model,
+        does necessary preprocessing,
+        and loads into the PgSTAC collection table
+        """
+        db_creds = self._get_db_credentials()
+        collection = [convert_decimals_to_float(collection.dict(by_alias=True))]
+        with PgstacDB(dsn=db_creds.dsn_string, debug=True) as db:
+            load_into_pgstac(
+                db=db, ingestions=collection, table=IngestionType.collections
+            )
+
+    def delete(self, collection_id: str):
+        """
+        Deletes the collection from the database
+        """
+        db_creds = self._get_db_credentials()
+        with PgstacDB(dsn=db_creds.dsn_string, debug=True) as db:
+            loader = VEDALoader(db=db)
+            loader.delete_collection(collection_id)
+
+    def _get_db_credentials(self) -> DbCreds:
+        if self.db_creds:
+            return self.db_creds
+        else:
+            return get_db_credentials(os.environ["DB_SECRET_ARN"])

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -20,8 +20,9 @@ class Settings(BaseSettings):
 
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: str = Field("", description="The Cognito APP client secret")
-    root_path: str = Field(description="Root path of API")
+    ingest_root_path: str = Field(description="Root path of API")
     stage: str = Field(description="API stage")
+    workflow_root_path: str = Field(description="Root path of API")
 
     class Config(AwsSsmSourceConfig):
         env_file = ".env"

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -270,6 +270,7 @@ async def publish_dataset(
     collection = schemas.DashboardCollection.parse_obj(collection_data)
     collection_publisher.ingest(collection)
 
+    # TODO improve typing
     return_dict = {
         "message": f"Successfully published collection: {dataset.collection}."
     }
@@ -281,8 +282,8 @@ async def publish_dataset(
             response = await start_discovery_workflow_execution(discovery)
             workflow_runs.append(response.id)
         if workflow_runs:
-            return_dict["message"] += f" {len(workflow_runs)} workflows initiated."
-            return_dict["workflows_ids"] = workflow_runs
+            return_dict["message"] += f" {len(workflow_runs)} workflows initiated."  # type: ignore
+            return_dict["workflows_ids"] = workflow_runs  # type: ignore
 
     return return_dict
 

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -199,21 +199,6 @@ class UpdateIngestionRequest(BaseModel):
     message: str = Field(None, description="Message of the ingestion")
 
 
-class Status(str, enum.Enum):
-    @classmethod
-    def _missing_(cls, value):
-        for member in cls:
-            if member.value.lower() == value.lower():
-                return member
-        return cls.unknown
-
-    started = "started"
-    queued = "queued"
-    failed = "failed"
-    succeeded = "succeeded"
-    cancelled = "cancelled"
-
-
 class WorkflowExecutionResponse(BaseModel):
     id: str = Field(
         ..., description="ID of the workflow execution in discover step function."
@@ -226,22 +211,6 @@ class WorkflowExecutionResponse(BaseModel):
 class ExecutionResponse(WorkflowExecutionResponse):
     message: str = Field(..., description="Message returned from the step function.")
     discovered_files: List[str] = Field(..., description="List of discovered files.")
-
-
-class AuthResponse(BaseModel):
-    AccessToken: str = Field(..., description="Token used to authenticate the user.")
-    ExpiresIn: int = Field(
-        ..., description="Number of seconds before the AccessToken expires."
-    )
-    TokenType: str = Field(
-        ..., description="Type of token being returned (e.g. 'Bearer')."
-    )
-    RefreshToken: str = Field(
-        ..., description="Token used to refresh the AccessToken when it expires."
-    )
-    IdToken: str = Field(
-        ..., description="Token containing information about the authenticated user."
-    )
 
 
 class WorkflowInputBase(BaseModel):

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -2,16 +2,25 @@ import base64
 import binascii
 import enum
 import json
+import re
 from datetime import datetime
 from decimal import Decimal
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 from urllib.parse import urlparse
 
 import src.validators as validators
-from pydantic import BaseModel, Field, PositiveInt, error_wrappers, validator
-from src.schema_helpers import SpatioTemporalExtent
+from pydantic import (
+    BaseModel,
+    Field,
+    PositiveInt,
+    error_wrappers,
+    root_validator,
+    validator,
+)
+from src.schema_helpers import BboxExtent, SpatioTemporalExtent, TemporalExtent
 from stac_pydantic import Collection, Item, shared
 from stac_pydantic.links import Link
+from typing_extensions import Annotated
 
 from fastapi.exceptions import RequestValidationError
 
@@ -188,3 +197,208 @@ class ListIngestionResponse(BaseModel):
 class UpdateIngestionRequest(BaseModel):
     status: Status = Field(None, description="Status of the ingestion")
     message: str = Field(None, description="Message of the ingestion")
+
+
+class Status(str, enum.Enum):
+    @classmethod
+    def _missing_(cls, value):
+        for member in cls:
+            if member.value.lower() == value.lower():
+                return member
+        return cls.unknown
+
+    started = "started"
+    queued = "queued"
+    failed = "failed"
+    succeeded = "succeeded"
+    cancelled = "cancelled"
+
+
+class WorkflowExecutionResponse(BaseModel):
+    id: str = Field(
+        ..., description="ID of the workflow execution in discover step function."
+    )
+    status: Status = Field(
+        ..., description="Status of the workflow execution in discover step function."
+    )
+
+
+class ExecutionResponse(WorkflowExecutionResponse):
+    message: str = Field(..., description="Message returned from the step function.")
+    discovered_files: List[str] = Field(..., description="List of discovered files.")
+
+
+class AuthResponse(BaseModel):
+    AccessToken: str = Field(..., description="Token used to authenticate the user.")
+    ExpiresIn: int = Field(
+        ..., description="Number of seconds before the AccessToken expires."
+    )
+    TokenType: str = Field(
+        ..., description="Type of token being returned (e.g. 'Bearer')."
+    )
+    RefreshToken: str = Field(
+        ..., description="Token used to refresh the AccessToken when it expires."
+    )
+    IdToken: str = Field(
+        ..., description="Token containing information about the authenticated user."
+    )
+
+
+class WorkflowInputBase(BaseModel):
+    collection: str = ""
+    upload: Optional[bool] = False
+    cogify: Optional[bool] = False
+    dry_run: bool = False
+
+    @validator("collection")
+    def exists(cls, collection):
+        """
+        Validate that the collection exists.
+
+        Parameters:
+        - collection (str): Name of the collection to be validated.
+
+        Returns:
+        - str: Name of the collection.
+        """
+        validators.collection_exists(collection_id=collection)
+        return collection
+
+
+class S3Input(WorkflowInputBase):
+    discovery: Literal["s3"]
+    prefix: str
+    bucket: str
+    filename_regex: str = r"[\s\S]*"  # default to match all files in prefix
+    datetime_range: Optional[str]
+    start_datetime: Optional[datetime]
+    end_datetime: Optional[datetime]
+    single_datetime: Optional[datetime]
+    zarr_store: Optional[str]
+
+    @root_validator
+    def object_is_accessible(cls, values):
+        bucket = values.get("bucket")
+        prefix = values.get("prefix")
+        zarr_store = values.get("zarr_store")
+        validators.s3_bucket_object_is_accessible(
+            bucket=bucket, prefix=prefix, zarr_store=zarr_store
+        )
+        return values
+
+
+class CmrInput(WorkflowInputBase):
+    discovery: Literal["cmr"]
+    version: Optional[str]
+    include: Optional[str]
+    temporal: Optional[List[datetime]]
+    bounding_box: Optional[List[float]]
+
+
+# allows the construction of models with a list of discriminated unions
+ItemUnion = Annotated[
+    Union[S3Input, CmrInput], Field(discriminator="discovery")  # noqa
+]
+
+
+class Dataset(BaseModel):
+    collection: str
+    title: str
+    description: str
+    license: str
+    is_periodic: Optional[bool] = False
+    time_density: Optional[str] = None
+    links: Optional[List[Link]] = []
+    discovery_items: List[ItemUnion]
+
+    # collection id must be all lowercase, with optional - delimiter
+    @validator("collection")
+    def check_id(cls, collection):
+        if not re.match(r"[a-z]+(?:-[a-z]+)*", collection):
+            # allow collection id to "break the rules" if an already-existing collection matches
+            try:
+                validators.collection_exists(collection_id=collection)
+            except ValueError:
+                # overwrite error - the issue isn't the non-existing function, it's the new id
+                raise ValueError(
+                    "Invalid id - id must be all lowercase, with optional '-' delimiters"
+                )
+        return collection
+
+    @root_validator
+    def check_time_density(cls, values):
+        validators.time_density_is_valid(values["is_periodic"], values["time_density"])
+        return values
+
+
+class DataType(str, enum.Enum):
+    cog = "cog"
+    zarr = "zarr"
+
+
+class COGDataset(Dataset):
+    spatial_extent: BboxExtent
+    temporal_extent: TemporalExtent
+    sample_files: List[str]  # unknown how this will work with CMR
+    data_type: Literal[DataType.cog]
+
+    @root_validator
+    def check_sample_files(cls, values):
+        # pydantic doesn't stop at the first validation,
+        # if the validation for s3 item access fails, "discovery_items" isn't returned
+        # this avoids throwing a KeyError
+        if not (discovery_items := values.get("discovery_items")):
+            return
+
+        if "s3" not in [item.discovery for item in discovery_items]:
+            return values
+
+        # TODO cmr handling/validation
+        invalid_fnames = []
+        for fname in values.get("sample_files", []):
+            found_match = False
+            for item in discovery_items:
+                if all(
+                    [
+                        item.discovery == "s3",
+                        re.search(item.filename_regex, fname.split("/")[-1]),
+                        "/".join(fname.split("/")[3:]).startswith(item.prefix),
+                    ]
+                ):
+                    if item.datetime_range:
+                        try:
+                            validators.extract_dates(fname, item.datetime_range)
+                        except Exception:
+                            raise ValueError(
+                                f"Invalid sample file - {fname} does not align"
+                                "with the provided datetime_range, and a datetime"
+                                "could not be extracted."
+                            )
+                    found_match = True
+            if not found_match:
+                invalid_fnames.append(fname)
+        if invalid_fnames:
+            raise ValueError(
+                f"Invalid sample files - {invalid_fnames} do not match any"
+                "of the provided prefix/filename_regex combinations."
+            )
+        return values
+
+
+class ZarrDataset(Dataset):
+    xarray_kwargs: Optional[Dict] = dict()
+    x_dimension: Optional[str]
+    y_dimension: Optional[str]
+    temporal_dimension: Optional[str]
+    reference_system: Optional[int]
+    data_type: Literal[DataType.zarr]
+
+    @validator("discovery_items")
+    def only_one_discover_item(cls, discovery_items):
+        if len(discovery_items) != 1:
+            raise ValueError("Zarr dataset should have exactly one discovery item")
+        if not discovery_items[0].zarr_store:
+            raise ValueError(
+                "Zarr dataset should include zarr_store in its discovery item"
+            )
+        return discovery_items

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -123,6 +123,16 @@ class CloudfrontDistributionConstruct(Construct):
                 allowed_methods=cf.AllowedMethods.ALLOW_ALL,
                 origin_request_policy=cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
             )
+            self.distribution.add_behavior(
+                "/api/workflows*",
+                origin=origins.HttpOrigin(
+                    f"{ingest_api.api_id}.execute-api.{region}.amazonaws.com",
+                    origin_id="workflow-api",
+                ),
+                cache_policy=cf.CachePolicy.CACHING_DISABLED,
+                allowed_methods=cf.AllowedMethods.ALLOW_ALL,
+                origin_request_policy=cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+            )
 
     def create_route_records(self, stage: str):
         """This is a seperate function so that it can be called after all behaviors are instantiated"""


### PR DESCRIPTION
## Why

- We need a way to run Airflow workflows in MCP, which requires an authenticated service.
- We added an ingest API to support direct submissions to the pgSTAC database.
- Both of these things are coupled by the "datasets" ingestion interface, which we want to continue supporting as our interactions with and usage of Airflow evolves.
- `veda-stac-ingestor` IAC and CICD has become difficult to maintain as our infrastructure grows more complex, and it has become easier to manage dependencies and utilize common patterns by deploying the same functionality under a common `veda-backend` stack. There is an accepted ADR that supports this change for `veda-features-api` - the same arguments apply to this repo.
- To support `dataset` endpoints without multiple cold starts, we host both APIs on the same Lambda. AFAIK the only downside of this is an empty API at https://qdo03dbjt6.execute-api.us-west-2.amazonaws.com/docs (not accessible through the CF domain however)

## What this means for users

- Dataset ingestions will still run using `{stage}.delta-backend.com/api/ingest/dataset/publish`. This replaces the old APIGW UUID url, but otherwise functions the same way.
- Airflow interactions will use `{stage}.delta-backend.com/api/workflows/`. Endpoints have been renamed to reflect that, eventually, we will need to run more than one "workflow" in this context (for example, vector ingests in MCP may need to invoke that workflow using this service)

## How to test
- Test stack APIs deployed to https://test.delta-backend.com/api/workflows/docs and https://test.delta-backend.com/api/ingest/docs. This isn't quite end-to-end, as no Airflow environment is pointing to this stack to submit ingests.
- `veda-data-airflow` needs updated CI to support MCP deployments/permissions
- In UAH, we can pass an `MWAA_ENV` pointing to an existing MWAA environment