### PR TITLE
fix: include stac url in ingestor config

### DIFF
--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -16,6 +16,8 @@ class Settings(BaseSettings):
         description="ARN of AWS Role used to validate access to S3 data"
     )
 
+    stac_url: AnyHttpUrl = Field(description="URL of STAC API")
+
     userpool_id: str = Field(description="The Cognito Userpool used for authentication")
 
     client_id: str = Field(description="The Cognito APP client ID")


### PR DESCRIPTION
The stac ingestor config is missing the `stac_url` environment variable and is causing the collection validator to fail. This PR adds back the `stac_url` in settings.

```
{
    "timestamp": "2024-02-12T15:34:51Z",
    "level": "ERROR",
    "message": "An error occurred running the application.",
    "logger": "mangum.http",
    "stackTrace": [
        "  File \"/var/task/mangum/protocols/http.py\", line 58, in run\n    await app(self.scope, self.receive, self.send)\n",
        "  File \"/var/task/fastapi/applications.py\", line 1054, in __call__\n    await super().__call__(scope, receive, send)\n",
        "  File \"/var/task/starlette/applications.py\", line 123, in __call__\n    await self.middleware_stack(scope, receive, send)\n",
        "  File \"/var/task/starlette/middleware/errors.py\", line 186, in __call__\n    raise exc\n",
        "  File \"/var/task/starlette/middleware/errors.py\", line 164, in __call__\n    await self.app(scope, receive, _send)\n",
        "  File \"/var/task/starlette/middleware/exceptions.py\", line 62, in __call__\n    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)\n",
        "  File \"/var/task/starlette/_exception_handler.py\", line 64, in wrapped_app\n    raise exc\n",
        "  File \"/var/task/starlette/_exception_handler.py\", line 53, in wrapped_app\n    await app(scope, receive, sender)\n",
        "  File \"/var/task/starlette/routing.py\", line 758, in __call__\n    await self.middleware_stack(scope, receive, send)\n",
        "  File \"/var/task/starlette/routing.py\", line 778, in app\n    await route.handle(scope, receive, send)\n",
        "  File \"/var/task/starlette/routing.py\", line 299, in handle\n    await self.app(scope, receive, send)\n",
        "  File \"/var/task/starlette/routing.py\", line 79, in app\n    await wrap_app_handling_exceptions(app, request)(scope, receive, send)\n",
        "  File \"/var/task/starlette/_exception_handler.py\", line 64, in wrapped_app\n    raise exc\n",
        "  File \"/var/task/starlette/_exception_handler.py\", line 53, in wrapped_app\n    await app(scope, receive, sender)\n",
        "  File \"/var/task/starlette/routing.py\", line 74, in app\n    response = await func(request)\n",
        "  File \"/var/task/fastapi/routing.py\", line 285, in app\n    raise e\n",
        "  File \"/var/task/fastapi/routing.py\", line 275, in app\n    solved_result = await solve_dependencies(\n",
        "  File \"/var/task/fastapi/dependencies/utils.py\", line 626, in solve_dependencies\n    ) = await request_body_to_args(  # body_params checked above\n",
        "  File \"/var/task/fastapi/dependencies/utils.py\", line 756, in request_body_to_args\n    v_, errors_ = field.validate(value, values, loc=loc)\n",
        "  File \"/var/task/pydantic/fields.py\", line 881, in validate\n    v, errors = self._validate_singleton(v, values, loc, cls)\n",
        "  File \"/var/task/pydantic/fields.py\", line 1098, in _validate_singleton\n    return self._apply_validators(v, values, loc, cls, self.validators)\n",
        "  File \"/var/task/pydantic/fields.py\", line 1154, in _apply_validators\n    v = validator(cls, v, values, self, self.model_config)\n",
        "  File \"/var/task/pydantic/class_validators.py\", line 337, in <lambda>\n    return lambda cls, v, values, field, config: validator(v)\n",
        "  File \"/var/task/pydantic/main.py\", line 711, in validate\n    return cls(**value)\n",
        "  File \"/var/task/pydantic/main.py\", line 339, in __init__\n    values, fields_set, validation_error = validate_model(__pydantic_self__.__class__, data)\n",
        "  File \"/var/task/pydantic/main.py\", line 1074, in validate_model\n    v_, errors_ = field.validate(value, values, loc=field.alias, cls=cls_)\n",
        "  File \"/var/task/pydantic/fields.py\", line 895, in validate\n    v, errors = self._apply_validators(v, values, loc, cls, self.post_validators)\n",
        "  File \"/var/task/pydantic/fields.py\", line 1154, in _apply_validators\n    v = validator(cls, v, values, self, self.model_config)\n",
        "  File \"/var/task/pydantic/class_validators.py\", line 304, in <lambda>\n    return lambda cls, v, values, field, config: validator(cls, v)\n",
        "  File \"/var/task/src/schemas.py\", line 44, in exists\n    validators.collection_exists(collection_id=collection)\n",
        "  File \"/var/task/src/validators.py\", line 84, in collection_exists\n    f'{url.strip(\"/\")}' for url in [settings.stac_url, \"collections\", collection_id]\n"
    ],
    "errorType": "AttributeError",
    "errorMessage": "'Settings' object has no attribute 'stac_url'",
    "requestId": "820dfb9f-67dd-4884-a82c-174fdbec5b41",
    "location": "/var/task/mangum/protocols/http.py:run:60"
}
```