### PR TITLE
fix: decimal to float serialization fix

### DIFF
--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import AnyHttpUrl, BaseSettings, Field, constr
 from pydantic_ssm_settings import AwsSsmSourceConfig
 
@@ -8,7 +10,7 @@ AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
 class Settings(BaseSettings):
     dynamodb_table: str
 
-    jwks_url: AnyHttpUrl = Field(
+    jwks_url: Optional[AnyHttpUrl] = Field(
         description="URL of JWKS, e.g. https://cognito-idp.{region}.amazonaws.com/{userpool_id}/.well-known/jwks.json"  # noqa
     )
 
@@ -22,8 +24,8 @@ class Settings(BaseSettings):
 
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: str = Field("", description="The Cognito APP client secret")
-    root_path: str = Field(description="Root path of API")
-    stage: str = Field(description="API stage")
+    root_path: Optional[str] = Field(description="Root path of API")
+    stage: Optional[str] = Field(description="API stage")
 
     class Config(AwsSsmSourceConfig):
         env_file = ".env"

--- a/ingest_api/runtime/src/ingestor.py
+++ b/ingest_api/runtime/src/ingestor.py
@@ -67,7 +67,7 @@ def handler(event: "events.DynamoDBStreamEvent", context: "context_.Context"):
 
     items = [
         # NOTE: Important to deserialize values to convert decimals to floats
-        convert_decimals_to_float(ingestion.item.model_dump())
+        convert_decimals_to_float(ingestion.item.to_dict())
         for ingestion in ingestions
     ]
 

--- a/ingest_api/runtime/src/ingestor.py
+++ b/ingest_api/runtime/src/ingestor.py
@@ -67,7 +67,7 @@ def handler(event: "events.DynamoDBStreamEvent", context: "context_.Context"):
 
     items = [
         # NOTE: Important to deserialize values to convert decimals to floats
-        convert_decimals_to_float(ingestion.item)
+        convert_decimals_to_float(ingestion.item.model_dump())
         for ingestion in ingestions
     ]
 


### PR DESCRIPTION
`convert_decimals_to_float` is expecting `dict` but we are passing type `Item`. Use ~`model_dump()`~  `to_dict()` to serialize Pydantic model to `dict`.

Also fixed `IngestorConstruct` lambda env variables pydantic validation in config `Settings()`.