### PR TITLE
fix: migrate stamen map references to stadia maps

### DIFF
--- a/stac_api/runtime/src/templates/stac-viewer.html
+++ b/stac_api/runtime/src/templates/stac-viewer.html
@@ -295,14 +295,11 @@ var map = new mapboxgl.Map({
         'toner-lite': {
           type: 'raster',
           tiles: [
-            'https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+            'https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}.png'
           ],
           tileSize: 256,
           attribution:
-            'Map tiles by <a href="https://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+            '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright/" target="_blank">OpenStreetMap</a>'
         }
       },
       layers: [


### PR DESCRIPTION
## Description
- This PR migrates Stamen Map references to use Stadia Maps (full migration notes [here](https://docs.stadiamaps.com/guides/migrating-from-stamen-map-tiles/))
- The migration is setup with my DevSeed email and to work with `*.delta-backend.com` domain

## Related Issues
https://github.com/NASA-IMPACT/veda-backend/issues/291

## Changes Made
- updates `stac-viewer.html` references from stamen maps to stadia maps

## Testing Done
[- Page now shows map](https://dev.delta-backend.com/api/stac/index.html)