### PR TITLE
fix: update iam role name for stac ingestor to be unique across stages

### DIFF
--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -120,6 +120,7 @@ class ApiConstruct(Construct):
         db_subnet_public: bool,
         code_dir: str = "./",
     ) -> apigateway.LambdaRestApi:
+        stack_name = Stack.of(self).stack_name
         handler_role = iam.Role(
             self,
             "execution-role",
@@ -127,7 +128,7 @@ class ApiConstruct(Construct):
                 "Role used by STAC Ingestor. Manually defined so that we can choose a "
                 "name that is supported by the data access roles trust policy"
             ),
-            role_name=f"delta-backend-staging-stac-ingestion-api-{stage}",
+            role_name=f"stac-ingestion-api-{stack_name}-role",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
             managed_policies=[
                 iam.ManagedPolicy.from_aws_managed_policy_name(


### PR DESCRIPTION
### Issue
- https://github.com/NASA-IMPACT/veda-backend/issues/308

### Changes Made
- updated the role name to use `stack_name` since the original `stage` variable would default to `runner` across different stages causing deployments to `dev` to fail

### Testing Done
- Locally deployed to dev successfully and confirmed that the previous resource `delta-backend-staging-stac-ingestion-api-runner` still exists and that `stac-ingestion-api-veda-backend-uah-dev-role` was created and the `dev` deployment succeeded