### PR TITLE
fix: update stac viewer endpoint value

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+
+### Issue
+
+Link to relevant GitHub issue
+
+### What?
+
+- Description of the changes made
+
+### Why?
+
+- Description of why the changes were made
+
+### Testing?
+
+- Relevant testing details
+

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -1,6 +1,7 @@
 """FastAPI application using PGStac.
 Based on https://github.com/developmentseed/eoAPI/tree/master/src/eoapi/stac
 """
+from pydantic import root_validator
 from aws_lambda_powertools.metrics import MetricUnit
 from src.config import ApiSettings, TilesApiSettings
 from src.config import extensions as PgStacExtensions
@@ -74,9 +75,10 @@ if tiles_settings.titiler_endpoint:
 @app.get("/index.html", response_class=HTMLResponse)
 async def viewer_page(request: Request):
     """Search viewer."""
+    path = api_settings.root_path or ""
     return templates.TemplateResponse(
         "stac-viewer.html",
-        {"request": request, "endpoint": str(request.url).replace("/index.html", "")},
+        {"request": request, "endpoint": str(request.url).replace("/index.html", path)},
         media_type="text/html",
     )
 

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -1,7 +1,6 @@
 """FastAPI application using PGStac.
 Based on https://github.com/developmentseed/eoAPI/tree/master/src/eoapi/stac
 """
-from pydantic import root_validator
 from aws_lambda_powertools.metrics import MetricUnit
 from src.config import ApiSettings, TilesApiSettings
 from src.config import extensions as PgStacExtensions

--- a/stac_api/runtime/src/templates/stac-viewer.html
+++ b/stac_api/runtime/src/templates/stac-viewer.html
@@ -662,7 +662,7 @@ const switchPane = (event) => {
 
 map.on('load', () => {
   // get collections
-  fetch('{{ endpoint }}/collections')
+  fetch('{{ endpoint }}/api/stac/collections')
     .then(res => {
       if (res.ok) return res.json()
       throw new Error('Network response was not ok.')

--- a/stac_api/runtime/src/templates/stac-viewer.html
+++ b/stac_api/runtime/src/templates/stac-viewer.html
@@ -662,7 +662,7 @@ const switchPane = (event) => {
 
 map.on('load', () => {
   // get collections
-  fetch('{{ endpoint }}/api/stac/collections')
+  fetch('{{ endpoint }}/collections')
     .then(res => {
       if (res.ok) return res.json()
       throw new Error('Network response was not ok.')


### PR DESCRIPTION
### Issue
https://github.com/NASA-IMPACT/veda-backend/issues/291

### What?

- Updated the endpoint value for the STAC viewer in order to properly render the collections on the webpage. 
- Added a PR template so that all new PRs will have a template for reference

### Why?

- The endpoint is https://dev.openveda.cloud/collections which is incorrect which causes the collections filter to fail in the STAC viewer. 

https://github.com/NASA-IMPACT/veda-backend/assets/12633533/b272fb4c-23a9-41c2-8ce8-925c6760231a


### Testing?

- I didn't locally deploy or anything but here is [the working collections link](https://dev.openveda.cloud/api/stac/collections)

### Notes
- I think we could technically also update https://github.com/NASA-IMPACT/veda-backend/blob/develop/stac_api/runtime/src/app.py#L79 to be:
```{"request": request, "endpoint": str(request.url).replace("/index.html", "/api/stac")},``` if that's preferred