### PR TITLE
fix: support automatic setting of search_path

### DIFF
--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -6,6 +6,7 @@ from aws_lambda_powertools.metrics import MetricUnit
 from src.algorithms import PostProcessParams
 from src.alternate_reader import PgSTACReaderAlt
 from src.config import ApiSettings
+from src.db import connect_to_rds_proxy
 from src.dependencies import ColorMapParams, ItemPathParams
 from src.extensions import stacViewerExtension
 from src.monitoring import LoggerRouteHandler, logger, metrics, tracer
@@ -39,11 +40,13 @@ else:
     optional_headers = []
 
 
+await connect_to_db()
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI Lifespan."""
     # Create Connection Pool
-    await connect_to_db(app, settings=settings.load_postgres_settings())
+    await connect_to_rds_proxy(app, settings=settings.load_postgres_settings())
     yield
     # Close the Connection Pool
     await close_db_connection(app)

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -23,7 +23,7 @@ from titiler.core.resources.enums import OptionalHeader
 from titiler.core.resources.responses import JSONResponse
 from titiler.extensions import cogValidateExtension, cogViewerExtension
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
-from titiler.pgstac.db import close_db_connection, connect_to_db
+from titiler.pgstac.db import close_db_connection
 from titiler.pgstac.factory import MosaicTilerFactory
 from titiler.pgstac.reader import PgSTACReader
 
@@ -39,8 +39,6 @@ if settings.debug:
 else:
     optional_headers = []
 
-
-await connect_to_db()
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/raster_api/runtime/src/db.py
+++ b/raster_api/runtime/src/db.py
@@ -1,0 +1,43 @@
+"""Database connection handling."""
+
+from typing import Optional
+
+from fastapi import FastAPI
+from psycopg_pool import ConnectionPool
+
+from titiler.pgstac.settings import PostgresSettings
+
+
+class RDSProxyConnectionPool(ConnectionPool):
+    """Subclassing connectionpool to ensure search path is set when connection is acquired"""
+    def getconn(self, key=None):
+        conn = super().getconn(key)
+        with conn.cursor() as cur:
+            cur.execute("SET search_path TO pgstac, public")
+        return conn
+
+async def connect_to_rds_proxy(
+    app: FastAPI, settings: Optional[PostgresSettings] = None
+) -> None:
+    """Connect to Database. Customized for RDS Proxy, so avoiding -c args"""
+    if not settings:
+        settings = PostgresSettings()
+
+    # Application can be provided by query parameters rather than -c
+    app.state.dbpool = RDSProxyConnectionPool(
+        conninfo=str(settings.database_url)+"?application_name=pgstac",
+        min_size=settings.db_min_conn_size,
+        max_size=settings.db_max_conn_size,
+        max_waiting=settings.db_max_queries,
+        max_idle=settings.db_max_idle,
+        num_workers=settings.db_num_workers
+    )
+
+    # Make sure the pool is ready
+    # ref: https://www.psycopg.org/psycopg3/docs/advanced/pool.html#pool-startup-check
+    app.state.dbpool.wait()
+
+
+async def close_db_connection(app: FastAPI) -> None:
+    """Close Pool."""
+    app.state.dbpool.close()

--- a/raster_api/runtime/src/db.py
+++ b/raster_api/runtime/src/db.py
@@ -2,19 +2,22 @@
 
 from typing import Optional
 
-from fastapi import FastAPI
 from psycopg_pool import ConnectionPool
 
+from fastapi import FastAPI
 from titiler.pgstac.settings import PostgresSettings
 
 
 class RDSProxyConnectionPool(ConnectionPool):
     """Subclassing connectionpool to ensure search path is set when connection is acquired"""
+
     def getconn(self, key=None):
+        """Automatically set search_path when connection is acquired"""
         conn = super().getconn(key)
         with conn.cursor() as cur:
             cur.execute("SET search_path TO pgstac, public")
         return conn
+
 
 async def connect_to_rds_proxy(
     app: FastAPI, settings: Optional[PostgresSettings] = None
@@ -25,12 +28,12 @@ async def connect_to_rds_proxy(
 
     # Application can be provided by query parameters rather than -c
     app.state.dbpool = RDSProxyConnectionPool(
-        conninfo=str(settings.database_url)+"?application_name=pgstac",
+        conninfo=str(settings.database_url) + "?application_name=pgstac",
         min_size=settings.db_min_conn_size,
         max_size=settings.db_max_conn_size,
         max_waiting=settings.db_max_queries,
         max_idle=settings.db_max_idle,
-        num_workers=settings.db_num_workers
+        num_workers=settings.db_num_workers,
     )
 
     # Make sure the pool is ready


### PR DESCRIPTION
This is a workaround for the error being encountered by titiler-pgstac's use of command line arguments. Application can be set via query paramaters and search_path is set by automatically executing `SET search_path` upon acquisition of connection