### PR TITLE
fix: migrate stamen map references to stadia maps raster api

### DIFF
--- a/raster_api/runtime/src/templates/stac-viewer.html
+++ b/raster_api/runtime/src/templates/stac-viewer.html
@@ -318,14 +318,11 @@ var map = new mapboxgl.Map({
         'toner-lite': {
           type: 'raster',
           tiles: [
-            'https://stamen-tiles-a.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-b.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-c.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png',
-            'https://stamen-tiles-d.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png'
+            'https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}.png'
           ],
           tileSize: 256,
           attribution:
-            'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
+            '&copy; <a href="https://stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright/" target="_blank">OpenStreetMap</a>'
         }
       },
       layers: [


### PR DESCRIPTION
### Issue
https://github.com/NASA-IMPACT/veda-backend/issues/291

### What?

- Update Stamen Maps to Stadia Maps 
### Why?

- Addressed this changed in a [previous PR](https://github.com/NASA-IMPACT/veda-backend/pull/301) but didn't realize that I needed to update the raster api as well 

### Testing?

- Local testing on vscode without deploying to dev