### PR TITLE
feat: configurable subnet ids

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,10 +118,7 @@ db_security_group = database.db_security_group
 
 # ingestor config requires references to other resources, but can be shared between ingest api and bulk ingestor
 ingestor_config = ingest_config(
-    stac_db_vpc_id=vpc.vpc.vpc_id,
-    stac_db_secret_name=db_secret_name,
     stac_db_security_group_id=db_security_group.security_group_id,
-    stac_db_public_subnet=database.is_publicly_accessible,
     stac_api_url=stac_api.stac_api.url,
     raster_api_url=raster_api.raster_api.url,
 )
@@ -133,6 +130,7 @@ ingest_api = ingest_api_construct(
     config=ingestor_config,
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
+    db_vpc_subnets=database.vpc_subnets,
     domain=domain,
 )
 
@@ -143,6 +141,7 @@ ingestor = ingestor_construct(
     table=ingest_api.table,
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
+    db_vpc_subnets=database.vpc_subnets,
 )
 
 veda_routes.add_ingest_behavior(

--- a/app.py
+++ b/app.py
@@ -64,7 +64,11 @@ else:
     vpc = VpcConstruct(veda_stack, "network", stage=veda_app_settings.stage_name())
 
 database = RdsConstruct(
-    veda_stack, "database", vpc.vpc, stage=veda_app_settings.stage_name()
+    veda_stack,
+    "database",
+    vpc=vpc.vpc,
+    subnet_ids=veda_app_settings.subnet_ids,
+    stage=veda_app_settings.stage_name(),
 )
 
 domain = DomainConstruct(veda_stack, "domain", stage=veda_app_settings.stage_name())

--- a/config.py
+++ b/config.py
@@ -1,12 +1,10 @@
 """App settings."""
 from getpass import getuser
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseSettings, Field, constr
 
-AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
-AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
-AwsOidcArn = constr(regex=r"^arn:aws:iam::\d{12}:oidc-provider/.+")
+AwsSubnetId = constr(regex=r"^subnet-[a-z0-9]{17}$")
 
 
 class vedaAppSettings(BaseSettings):
@@ -41,6 +39,10 @@ class vedaAppSettings(BaseSettings):
             "Resource identifier of VPC, if none a new VPC with public and private "
             "subnets will be provisioned."
         ),
+    )
+    subnet_ids: Optional[List[AwsSubnetId]] = Field(
+        [],
+        description="The subnet ids of subnets associated with the VPC to be used for the database and lambda function."
     )
     cdk_default_account: Optional[str] = Field(
         None,

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 """App settings."""
 from getpass import getuser
-from typing import Optional, List
+from typing import List, Optional
 
 from pydantic import BaseSettings, Field, constr
 
@@ -40,9 +40,9 @@ class vedaAppSettings(BaseSettings):
             "subnets will be provisioned."
         ),
     )
-    subnet_ids: Optional[List[AwsSubnetId]] = Field(
+    subnet_ids: Optional[List[AwsSubnetId]] = Field(  # type: ignore
         [],
-        description="The subnet ids of subnets associated with the VPC to be used for the database and lambda function."
+        description="The subnet ids of subnets associated with the VPC to be used for the database and lambda function.",
     )
     cdk_default_account: Optional[str] = Field(
         None,

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -156,10 +156,14 @@ class RdsConstruct(Construct):
         )
 
         # Configure accessibility
-        if (subnet_ids):
+        if subnet_ids:
             self.vpc_subnets = aws_ec2.SubnetSelection(
-                subnets=[aws_ec2.Subnet.from_subnet_attributes(self, f"Subnet{i}", subnet_id=subnet_id)
-                         for i, subnet_id in enumerate(subnet_ids)]
+                subnets=[
+                    aws_ec2.Subnet.from_subnet_attributes(
+                        self, f"Subnet{i}", subnet_id=subnet_id
+                    )
+                    for i, subnet_id in enumerate(subnet_ids)
+                ]
             )
         else:
             subnet_type = (

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -1,7 +1,7 @@
 """CDK Construct for veda-backend RDS instance."""
 import json
 import os
-from typing import Union
+from typing import List, Optional, Union
 
 from aws_cdk import (
     CfnOutput,
@@ -36,7 +36,6 @@ class BootstrapPgStac(Construct):
         new_dbname: str,
         new_username: str,
         secrets_prefix: str,
-        stage: str,
         host: str,
     ) -> None:
         """."""
@@ -119,6 +118,7 @@ class RdsConstruct(Construct):
         scope: Construct,
         construct_id: str,
         vpc: aws_ec2.Vpc,
+        subnet_ids: Optional[List],
         stage: str,
         **kwargs,
     ) -> None:
@@ -128,13 +128,6 @@ class RdsConstruct(Construct):
         # The code that defines your stack goes here
 
         stack_name = Stack.of(self).stack_name
-
-        # Configure accessibility
-        subnet_type = (
-            aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
-            if veda_db_settings.publicly_accessible is False
-            else aws_ec2.SubnetType.PUBLIC
-        )
 
         # Custom parameter group
         engine = aws_rds.DatabaseInstanceEngine.postgres(
@@ -162,6 +155,20 @@ class RdsConstruct(Construct):
             },
         )
 
+        # Configure accessibility
+        if (subnet_ids):
+            self.vpc_subnets = aws_ec2.SubnetSelection(
+                subnets=[aws_ec2.Subnet.from_subnet_attributes(self, f"Subnet{i}", subnet_id=subnet_id)
+                         for i, subnet_id in enumerate(subnet_ids)]
+            )
+        else:
+            subnet_type = (
+                aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
+                if not veda_db_settings.publicly_accessible
+                else aws_ec2.SubnetType.PUBLIC
+            )
+            self.vpc_subnets = aws_ec2.SubnetSelection(subnet_type=subnet_type)
+
         # Database Configurations
         database_config = {
             "id": "rds",
@@ -169,12 +176,13 @@ class RdsConstruct(Construct):
             "vpc": vpc,
             "engine": engine,
             "instance_type": rds_instance_type,
-            "vpc_subnets": aws_ec2.SubnetSelection(subnet_type=subnet_type),
+            "vpc_subnets": self.vpc_subnets,
             "deletion_protection": True,
             "removal_policy": RemovalPolicy.RETAIN,
             "publicly_accessible": veda_db_settings.publicly_accessible,
             "parameter_group": parameter_group,
         }
+
         if veda_db_settings.rds_encryption:
             database_config["storage_encrypted"] = veda_db_settings.rds_encryption
 
@@ -208,7 +216,6 @@ class RdsConstruct(Construct):
             new_dbname=veda_db_settings.dbname,
             new_username=veda_db_settings.user,
             secrets_prefix=stack_name,
-            stage=stage,
             host=hostname,
         )
 

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -5,8 +5,6 @@ import aws_cdk
 from pydantic import BaseSettings, Field, constr
 
 AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
-AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
-AwsOidcArn = constr(regex=r"^arn:aws:iam::\d{12}:oidc-provider/.+")
 
 
 class IngestorConfig(BaseSettings):
@@ -36,17 +34,8 @@ class IngestorConfig(BaseSettings):
     client_secret: Optional[str] = Field(
         "", description="The Cognito APP client secret"
     )
-
-    stac_db_secret_name: str = Field(
-        description="Name of secret containing pgSTAC DB connection information"
-    )
-    stac_db_vpc_id: str = Field(description="ID of VPC running pgSTAC DB")
     stac_db_security_group_id: str = Field(
         description="ID of Security Group used by pgSTAC DB"
-    )
-    stac_db_public_subnet: bool = Field(
-        description="Boolean indicating whether or not pgSTAC DB is in a public subnet",
-        default=True,
     )
 
     raster_data_access_role_arn: AwsArn = Field(  # type: ignore

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -70,7 +70,6 @@ class ApiConstruct(Construct):
             env=lambda_env,
             data_access_role=self.data_access_role,
             user_pool=self.user_pool,
-            stage=config.stage,
             db_secret=db_secret,
             db_vpc=db_vpc,
             db_security_group=db_security_group,
@@ -283,7 +282,7 @@ class IngestorConstruct(Construct):
             db_secret=db_secret,
             db_vpc=db_vpc,
             db_security_group=db_security_group,
-            db_vpc_subnets=db_vpc_subnets
+            db_vpc_subnets=db_vpc_subnets,
         )
 
     def build_ingestor(

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -4,7 +4,6 @@ from pydantic import AnyHttpUrl, BaseSettings, Field, constr
 from pydantic_ssm_settings import AwsSsmSourceConfig
 
 AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
-AwsStepArn = constr(regex=r"^arn:aws:states:.+:\d{12}:stateMachine:.+")
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
### What?

- Allows users to specify the subnet IDs to be used for the database

### Why?

- Since we don't always get to create our own VPC, the subnets associated with it are not always one or the other type. We've had issues in the past with the private subnet type not being available in the VPC (`PRIVATE_ISOLATED`, `PRIVATE_EGRESS`, etc. This allows users to specify the subnet ids so we don't rely on a specific type.

### Testing?

- Deployed and manually checked that the database and the ingest lambdas were associated to the subnets provided

