### PR TITLE
fix: update condition for setting storage_encrypted

### DIFF
--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -187,7 +187,8 @@ class RdsConstruct(Construct):
             "parameter_group": parameter_group,
         }
 
-        if veda_db_settings.rds_encryption:
+        # Only set storage_encrypted if creating a database instance not from snapshot
+        if not veda_db_settings.snapshot_id and veda_db_settings.rds_encryption:
             database_config["storage_encrypted"] = veda_db_settings.rds_encryption
 
         # Create a new database instance from snapshot if provided

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -187,7 +187,8 @@ class RdsConstruct(Construct):
             "parameter_group": parameter_group,
         }
 
-        # Only set storage_encrypted if creating a database instance not from snapshot
+        # Only set storage_encrypted if creating a database instance not from snapshot. Use an encrypted snapshot when creating a new encrypted database from a snapshot.
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstanceFromSnapshot.html
         if not veda_db_settings.snapshot_id and veda_db_settings.rds_encryption:
             database_config["storage_encrypted"] = veda_db_settings.rds_encryption
 


### PR DESCRIPTION
### Issue

[Link to relevant GitHub issue](https://github.com/NASA-IMPACT/veda-architecture/issues/353)

### What?

- This is the original work https://github.com/NASA-IMPACT/veda-backend/pull/218/files which I'm making slight modifications of since the parameter storage_encrypted is not a part of [DatabaseInstanceFromSnapshot](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstanceFromSnapshot.html), but it is a valid parameter of [DatabaseInstance](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_rds/DatabaseInstance.html).

### Why?

- In testing a test deployment that uses a snapshot, the deployment errors with:
```
Traceback (most recent call last):
  File "/home/runner/work/veda-deploy/veda-deploy/veda-backend/app.py", line 66, in <module>
    database = RdsConstruct(
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/jsii/_runtime.py", line 118, in __call__
    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
  File "/home/runner/work/veda-deploy/veda-deploy/veda-backend/database/infrastructure/construct.py", line 200, in __init__
    database = aws_rds.DatabaseInstanceFromSnapshot(
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/site-packages/jsii/_runtime.py", line 118, in __call__
    inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'storage_encrypted'
Subprocess exited with error 1
```

### Testing?

- TBD

