### PR TITLE
chore: test api responses against openapi spec

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -58,13 +58,13 @@ jobs:
       - name: Sleep for 10 seconds
         run: sleep 10s
         shell: bash
+
+      - name: Install reqs for unit and integration tests
+        run: python -m pip install -r ingest_api/runtime/requirements.txt
   
       - name: Integrations tests
         run: python -m pytest .github/workflows/tests/ -vv -s
-      
-      - name: Install reqs for unit tests
-        run: python -m pip install -r ingest_api/runtime/requirements.txt
-      
+
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -74,12 +74,12 @@ jobs:
       - name: Sleep for 10 seconds
         run: sleep 10s
         shell: bash
+      
+      - name: Install reqs for unit tests
+        run: python -m pip install -r ingest_api/runtime/requirements.txt
   
       - name: Integrations tests
         run: python -m pytest .github/workflows/tests/ -vv -s
-
-      - name: Install reqs for unit tests
-        run: python -m pip install -r ingest_api/runtime/requirements.txt
       
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s

--- a/.github/workflows/tests/schemas/collection_schema.json
+++ b/.github/workflows/tests/schemas/collection_schema.json
@@ -1,0 +1,109 @@
+{
+  "type": "object",
+  "required": [
+    "stac_version",
+    "id",
+    "description",
+    "license",
+    "extent",
+    "links"
+  ],
+  "properties": {
+    "stac_version": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "Collection"
+      ]
+    },
+    "id": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed multi-line description to fully explain the catalog or collection.\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation."
+    },
+    "keywords": {
+      "type": "array",
+      "description": "List of keywords describing the collection.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "license": {
+      "type": "string"
+    },
+    "extent": {
+      "type": "object",
+      "required": [
+        "spatial",
+        "temporal"
+      ],
+      "properties": {
+        "spatial": {
+          "type": "object",
+          "required": [
+            "bbox"
+          ],
+          "properties": {
+            "bbox": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "array",
+                "minItems": 4,
+                "maxItems": 6,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "temporal": {
+          "type": "object",
+          "required": [
+            "interval"
+          ],
+          "properties": {
+            "interval": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "maxItems": 2,
+                "items": {
+                  "type": "string",
+                  "format": "date-time",
+                  "nullable": "true"
+                }
+              }
+            }
+          }
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "href",
+              "rel"
+            ],
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "rel": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/tests/schemas/feature_schema.json
+++ b/.github/workflows/tests/schemas/feature_schema.json
@@ -1,0 +1,63 @@
+{
+    "type": "object",
+    "required": [
+        "id",
+        "bbox",
+        "type",
+        "links",
+        "stac_version",
+        "stac_extensions"
+    ],
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "bbox": {
+            "type": "array"
+        },
+        "type": {
+            "type": "string"
+        },
+        "links": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rel": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string"
+                    },
+                    "href": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "assets": {
+            "type": "object"
+        },
+        "geometry": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "coordinates": "array"
+                }
+            }
+        },
+        "collection": {
+            "type": "string"
+        },
+        "properties": {
+            "type": "object"
+        },
+        "stac_version": {
+            "type": "string"
+        },
+        "stac_extensions": {
+            "type": "array"
+        }
+    }
+}

--- a/.github/workflows/tests/test_stac.py
+++ b/.github/workflows/tests/test_stac.py
@@ -1,124 +1,17 @@
 """test veda-backend STAC."""
 
+import json
+
 import httpx
 from openapi_schema_validator import validate
 
+with open(".github/workflows/tests/schemas/feature_schema.json", "r") as f:
+    feature_schema = json.load(f)
+
+with open(".github/workflows/tests/schemas/collection_schema.json", "r") as f:
+    collection_schema = json.load(f)
+
 stac_endpoint = "http://0.0.0.0:8081"
-
-
-feature_schema = {
-    "type": "object",
-    "required": ["id", "bbox", "type", "links", "stac_version", "stac_extensions"],
-    "properties": {
-        "id": {"type": "string"},
-        "bbox": {"type": "array"},
-        "type": {"type": "string"},
-        "links": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "rel": {"type": "string"},
-                    "type": {"type": "string"},
-                    "href": {"type": "string"},
-                },
-            },
-        },
-        "assets": {"type": "object"},
-        "geometry": {
-            "type": "object",
-            "properties": {"type": {"type": "string", "coordinates": "array"}},
-        },
-        "collection": {"type": "string"},
-        "properties": {"type": "object"},
-        "stac_version": {"type": "string"},
-        "stac_extensions": {"type": "array"},
-    },
-}
-
-collection_schema = {
-    "type": "object",
-    "required": [
-        "stac_version",
-        # "type",
-        "id",
-        "description",
-        "license",
-        "extent",
-        "links",
-    ],
-    "properties": {
-        "stac_version": {"type": "string"},
-        "type": {"type": "string", "enum": ["Collection"]},
-        "id": {
-            "type": "string",
-        },
-        "description": {
-            "type": "string",
-            "description": "Detailed multi-line description to fully explain the catalog or collection.\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.",
-        },
-        "keywords": {
-            "type": "array",
-            "description": "List of keywords describing the collection.",
-            "items": {"type": "string"},
-        },
-        "license": {"type": "string"},
-        "extent": {
-            "type": "object",
-            "required": ["spatial", "temporal"],
-            "properties": {
-                "spatial": {
-                    "type": "object",
-                    "required": ["bbox"],
-                    "properties": {
-                        "bbox": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "array",
-                                "minItems": 4,
-                                "maxItems": 6,
-                                "items": {"type": "number"},
-                            },
-                        }
-                    },
-                },
-                "temporal": {
-                    "type": "object",
-                    "required": ["interval"],
-                    "properties": {
-                        "interval": {
-                            "type": "array",
-                            "minItems": 1,
-                            "items": {
-                                "type": "array",
-                                "minItems": 2,
-                                "maxItems": 2,
-                                "items": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": "true",
-                                },
-                            },
-                        },
-                    },
-                },
-                "links": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "required": ["href", "rel"],
-                        "properties": {
-                            "href": {"type": "string", "format": "uri"},
-                            "rel": {"type": "string"},
-                        },
-                    },
-                },
-            },
-        },
-    },
-}
-
 
 def test_stac_api():
     """test stac."""
@@ -151,6 +44,7 @@ def test_stac_api():
     assert resp.status_code == 200
     item = resp.json()
     assert item["id"] == "20200307aC0853300w361200"
+    validate(item, feature_schema)
 
 
 def test_stac_to_raster():

--- a/.github/workflows/tests/test_stac.py
+++ b/.github/workflows/tests/test_stac.py
@@ -1,8 +1,123 @@
 """test veda-backend STAC."""
 
 import httpx
+from openapi_schema_validator import validate
 
 stac_endpoint = "http://0.0.0.0:8081"
+
+
+feature_schema = {
+    "type": "object",
+    "required": ["id", "bbox", "type", "links", "stac_version", "stac_extensions"],
+    "properties": {
+        "id": {"type": "string"},
+        "bbox": {"type": "array"},
+        "type": {"type": "string"},
+        "links": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "rel": {"type": "string"},
+                    "type": {"type": "string"},
+                    "href": {"type": "string"},
+                },
+            },
+        },
+        "assets": {"type": "object"},
+        "geometry": {
+            "type": "object",
+            "properties": {"type": {"type": "string", "coordinates": "array"}},
+        },
+        "collection": {"type": "string"},
+        "properties": {"type": "object"},
+        "stac_version": {"type": "string"},
+        "stac_extensions": {"type": "array"},
+    },
+}
+
+collection_schema = {
+    "type": "object",
+    "required": [
+        "stac_version",
+        # "type",
+        "id",
+        "description",
+        "license",
+        "extent",
+        "links",
+    ],
+    "properties": {
+        "stac_version": {"type": "string"},
+        "type": {"type": "string", "enum": ["Collection"]},
+        "id": {
+            "type": "string",
+        },
+        "description": {
+            "type": "string",
+            "description": "Detailed multi-line description to fully explain the catalog or collection.\n[CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation.",
+        },
+        "keywords": {
+            "type": "array",
+            "description": "List of keywords describing the collection.",
+            "items": {"type": "string"},
+        },
+        "license": {"type": "string"},
+        "extent": {
+            "type": "object",
+            "required": ["spatial", "temporal"],
+            "properties": {
+                "spatial": {
+                    "type": "object",
+                    "required": ["bbox"],
+                    "properties": {
+                        "bbox": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "array",
+                                "minItems": 4,
+                                "maxItems": 6,
+                                "items": {"type": "number"},
+                            },
+                        }
+                    },
+                },
+                "temporal": {
+                    "type": "object",
+                    "required": ["interval"],
+                    "properties": {
+                        "interval": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": "true",
+                                },
+                            },
+                        },
+                    },
+                },
+                "links": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["href", "rel"],
+                        "properties": {
+                            "href": {"type": "string", "format": "uri"},
+                            "rel": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
 
 
 def test_stac_api():
@@ -18,6 +133,7 @@ def test_stac_api():
     assert resp.status_code == 200
     collections = resp.json()["collections"]
     assert len(collections) > 0
+    validate(collections[0], collection_schema)
     ids = [c["id"] for c in collections]
     assert "noaa-emergency-response" in ids
 
@@ -25,6 +141,7 @@ def test_stac_api():
     resp = httpx.get(f"{stac_endpoint}/collections/noaa-emergency-response/items")
     assert resp.status_code == 200
     items = resp.json()["features"]
+    validate(items[0], feature_schema)
     assert len(items) == 10
 
     # item

--- a/.github/workflows/tests/test_stac.py
+++ b/.github/workflows/tests/test_stac.py
@@ -13,6 +13,7 @@ with open(".github/workflows/tests/schemas/collection_schema.json", "r") as f:
 
 stac_endpoint = "http://0.0.0.0:8081"
 
+
 def test_stac_api():
     """test stac."""
     # Ping

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -17,3 +17,4 @@ xarray==2023.1.0
 xstac==1.1.0
 zarr==2.13.6
 boto3==1.24.59
+openapi_schema_validator>=0.6.2


### PR DESCRIPTION
### What?

Currently, we test the api endpoints to ensure the correct response code (e.g. `200`).  This is a POC to use the open api validator to validate the response body against the stac open api spec.  Currently, the docs are showing the response for these two endpoints as just any string.  I've used a subset of the open api spec at https://api.stacspec.org/ to manually enter in a schema for now.

### Testing?

these tests can be run locally with the existing shell script: `./scripts/run-local-tests.sh`

