### PR TITLE
fix(api): do not override ingest api subnet config

### DIFF
--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -136,7 +136,7 @@ class ApiConstruct(Construct):
 
         handler = aws_lambda.Function(
             self,
-            "Api",
+            "api-handler",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",
@@ -294,7 +294,7 @@ class IngestorConstruct(Construct):
     ) -> aws_lambda.Function:
         handler = aws_lambda.Function(
             self,
-            "Loader",
+            "stac-ingestor",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -138,7 +138,7 @@ class ApiConstruct(Construct):
 
         handler = aws_lambda.Function(
             self,
-            "ingest-api",
+            "Api",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",
@@ -298,7 +298,7 @@ class IngestorConstruct(Construct):
     ) -> aws_lambda.Function:
         handler = aws_lambda.Function(
             self,
-            "ingest-loader",
+            "Loader",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -138,7 +138,7 @@ class ApiConstruct(Construct):
 
         handler = aws_lambda.Function(
             self,
-            "api-handler",
+            "ingest-api",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",
@@ -150,8 +150,8 @@ class ApiConstruct(Construct):
             role=handler_role,
             environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
             vpc=db_vpc,
-            vpc_subnets=db_vpc_subnets,
-            allow_public_subnet=True,
+            # vpc_subnets=db_vpc_subnets,
+            # allow_public_subnet=True,
             memory_size=2048,
             log_format="JSON",
         )
@@ -298,7 +298,7 @@ class IngestorConstruct(Construct):
     ) -> aws_lambda.Function:
         handler = aws_lambda.Function(
             self,
-            "stac-ingestor",
+            "ingest-loader",
             code=aws_lambda.Code.from_docker_build(
                 path=os.path.abspath(code_dir),
                 file="ingest_api/runtime/Dockerfile",

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -73,7 +73,6 @@ class ApiConstruct(Construct):
             db_secret=db_secret,
             db_vpc=db_vpc,
             db_security_group=db_security_group,
-            db_vpc_subnets=db_vpc_subnets,
         )
 
         # create API
@@ -116,7 +115,6 @@ class ApiConstruct(Construct):
         db_secret: secretsmanager.ISecret,
         db_vpc: ec2.IVpc,
         db_security_group: ec2.ISecurityGroup,
-        db_vpc_subnets: ec2.SubnetSelection,
         code_dir: str = "./",
     ) -> apigateway.LambdaRestApi:
         stack_name = Stack.of(self).stack_name
@@ -150,8 +148,6 @@ class ApiConstruct(Construct):
             role=handler_role,
             environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
             vpc=db_vpc,
-            # vpc_subnets=db_vpc_subnets,
-            # allow_public_subnet=True,
             memory_size=2048,
             log_format="JSON",
         )


### PR DESCRIPTION
### Issue
https://github.com/NASA-IMPACT/veda-backend/issues/328

### What?
Do not override the subnet configuration for the ingest api lambda.

### Why?
Authenticated endpoints deployed to public subnets do not work using cloudfront

### Testing?
- Github PR action that runs cdk diff looks good
- Manually deployed to dev and confirmed that ingest api lambda in private subnets
- Confirmed AGW url and cloudfront url token and whoampi endpoints work
- Edited and reverted one collection
