### PR TITLE
fix: api dependencies upgrade

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -71,8 +71,27 @@ jobs:
       - name: Stop services
         run: docker compose stop
 
-  deploy-dev:
+  pre-release:
     needs: [test-dev]
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Python Semantic Release
+      uses: python-semantic-release/python-semantic-release@master
+      with:
+        changelog: "false"
+        vcs-release: "true"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy-dev:
+    needs: [pre-release]
 
     runs-on: ubuntu-latest
     steps:
@@ -120,22 +139,3 @@ jobs:
         run: |
           echo $STAGE
           cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json
-
-  pre-release:
-    needs: [deploy-dev]
-    runs-on: ubuntu-latest
-    concurrency: release
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Python Semantic Release
-      uses: python-semantic-release/python-semantic-release@master
-      with:
-        changelog: "false"
-        vcs-release: "true"
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -9,13 +9,13 @@ jobs:
   lint-dev:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -32,13 +32,13 @@ jobs:
     needs: [lint-dev]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -77,9 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -95,7 +95,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -103,7 +103,7 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -130,7 +130,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Python Semantic Release

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,13 +9,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
     
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -32,13 +32,13 @@ jobs:
     needs: [lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -71,9 +71,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       
@@ -89,7 +89,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -97,7 +97,7 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
       
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -124,7 +124,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Python Semantic Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with: 
-          node-version: 17
+          node-version: 20
       
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,8 +65,27 @@ jobs:
       - name: Stop services
         run: docker compose stop
 
-  deploy: 
+  release:
     needs: [test]
+    runs-on: ubuntu-latest
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Python Semantic Release
+      uses: python-semantic-release/python-semantic-release@master
+      with:
+        changelog: "false"
+        vcs-release: "true"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy: 
+    needs: [release]
 
     runs-on: ubuntu-latest
     steps:
@@ -114,23 +133,4 @@ jobs:
         run: |
           echo $STAGE
           cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json
-
-  release:
-    needs: [deploy]
-    runs-on: ubuntu-latest
-    concurrency: release
-    permissions:
-      id-token: write
-      contents: write
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Python Semantic Release
-      uses: python-semantic-release/python-semantic-release@master
-      with:
-        changelog: "false"
-        vcs-release: "true"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
           

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 17
+          node-version: 20
 
       - name: Configure awscli
         uses: aws-actions/configure-aws-credentials@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,13 +6,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -28,20 +28,16 @@ jobs:
   lint-conventional-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: CondeNast/conventional-pull-request-action@v0.2.0
+      - uses: actions/checkout@v4
+      - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # if the PR contains a single commit, fail if the commit message and the PR title do not match
-          commitTitleMatch: "true"
-          ignoreCommits: "true"
 
   test:
     needs: [lint, lint-conventional-pr]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Launch services
         run: |
@@ -50,11 +46,11 @@ jobs:
           docker compose up --build -d
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}
@@ -93,9 +89,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -111,7 +107,7 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
@@ -119,7 +115,7 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk@2
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
           key:  ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This project generally follows the [git-flow branching model](https://nvie.com/p
 
 - Pull requests should explain **what** is changed, **why**, and **how the change can be tested**.
   
-- Pull request *titles* must adhere to the [conventional commits specification]([#conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/)). This is enforced using the  [conventional-pull-request-action](https://github.com/CondeNast/conventional-pull-request-action).  
+- Pull request *titles* must adhere to the [conventional commits specification]([#conventional-commits](https://www.conventionalcommits.org/en/v1.0.0/)). This is enforced using [action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).  
 
 - Successful automated pull request linting, testing, and deployment checks are required.
 

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -9,7 +9,7 @@ psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.10.12
 pypgstac==0.7.4
-python-multipart==0.0.5
+python-multipart==0.0.7
 requests>=2.27.1
 s3fs==2023.3.0
 stac-pydantic @ git+https://github.com/ividito/stac-pydantic.git@3f4cb381c85749bb4b15d1181179057ec0f51a94

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -14,7 +14,6 @@ inst_reqs = [
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
-    "starlette>=0.36.2",
 ]
 
 extra_reqs = {

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -14,6 +14,7 @@ inst_reqs = [
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
+    "python-multipart==0.0.7",
 ]
 
 extra_reqs = {

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -14,7 +14,7 @@ inst_reqs = [
     "starlette-cramjam>=0.3,<0.4",
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
-    "starlette<0.28",
+    "starlette>=0.36.2",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
# fixed
- python-multipart upgraded for security
- starlette version un-pinned (let fastapi manage this)

# ci
- all github actions upgraded to resolve node outdated node warnings
- conventional pr title linting action replaced with https://github.com/amannn/action-semantic-pull-request which can run on node > 16
- release tag generated before deployment in both develop and main workflows (makes it easier to re-run last deployment with configuration changes and should add the git release tag to the tags on aws resources)

## Notes
Two dependabot alerts point back to the same python-multipart vulnerability, the second suggest upgrading starlette to version [0.36.2](https://github.com/encode/starlette/releases/tag/0.36.2) (the first release that pins python-multipart version at all). This PR instead requires `python-multipart>=0.0.7` which will be compatible with older versions of starlette needed by our other dependencies.


## issue
#297
