### PR TITLE
ci: fix vcs release in deploy and upgrade action versions

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -102,12 +102,12 @@ jobs:
           python-version: '3.9'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -87,7 +87,6 @@ jobs:
       uses: python-semantic-release/python-semantic-release@master
       with:
         changelog: "false"
-        vcs-release: "true"
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-dev:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,6 @@ jobs:
       uses: python-semantic-release/python-semantic-release@master
       with:
         changelog: "false"
-        vcs-release: "true"
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy: 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,12 +96,12 @@ jobs:
           python-version: '3.9'
       
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with: 
           node-version: 20
       
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This PR catches a few missed git action deprecated node warnings and removes an invalid input parameter from semantic release step.