### PR TITLE
fix: stac browser catalog url with cloudfront

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - develop
+    - fix/stac-browser
 
 jobs:
   lint-dev:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - develop
-    - fix/stac-browser
 
 jobs:
   lint-dev:

--- a/config.py
+++ b/config.py
@@ -131,7 +131,7 @@ class vedaAppSettings(BaseSettings):
     def get_stac_catalog_url(self) -> Optional[str]:
         """Infer stac catalog url based on whether the app is configured to deploy the catalog to a custom subdomain or to a cloudfront route"""
         if self.veda_custom_host and self.veda_stac_root_path:
-            return f"https://{veda_app_settings.veda_custom_host}/{veda_app_settings.veda_stac_root_path.lstrip('/')}"
+            return f"https://{veda_app_settings.veda_custom_host}{veda_app_settings.veda_stac_root_path}/"
         if (
             self.veda_domain_create_custom_subdomains
             and self.veda_domain_hosted_zone_name


### PR DESCRIPTION
## What
Force a trailing slash on the stac catalog url when building a stac-browser for a stac-api behind a cloudfront.

## How tested
I temporarily updated the deploy action to push to the dev stack on push to this fix branch and confirmed that the browser at dev.openveda.cloud properly finds the stac api at dev.openveda.cloud/api/stac/.

