### PR TITLE
chore: make unit tests compatible with moto 5 and bump moto version

### DIFF
--- a/ingest_api/runtime/tests/conftest.py
+++ b/ingest_api/runtime/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import boto3
 import pytest
-from moto import mock_dynamodb, mock_ssm
+from moto import mock_aws
 from stac_pydantic import Item
 
 from fastapi.testclient import TestClient
@@ -32,7 +32,7 @@ def test_environ():
 
 @pytest.fixture
 def mock_ssm_parameter_store():
-    with mock_ssm():
+    with mock_aws():
         yield boto3.client("ssm", region_name="us-west-2")
 
 
@@ -52,7 +52,7 @@ def api_client(app):
 def mock_table(app, test_environ):
     from src import dependencies, main
 
-    with mock_dynamodb():
+    with mock_aws():
         client = boto3.resource("dynamodb", region_name="us-west-2")
         mock_table = client.create_table(
             TableName=main.settings.dynamodb_table,

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
         "fastapi",
-        "moto",
+        "moto~=5.0",
     ],
 }
 


### PR DESCRIPTION
### Issue
The Unit tests appear to be using the old syntax for moto, but that was breaking when trying to use the `openapi_schema_validator` package.  See comments in that PR:
https://github.com/NASA-IMPACT/veda-backend/pull/333#issuecomment-1998562269

### What?

set the `setup.py` to use `moto~=5.0`

it looks like moto is only imported & defined in the `conftest.py` fixtures, so I made the upgrade to the updated syntax there.


### Testing?

The only changes made centered around the unit tests, so ensure that they still run & pass.

