### PR TITLE
fix(db)!: update collection summaries on load items

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -63,7 +63,7 @@ jobs:
         run: python -m pytest .github/workflows/tests/ -vv -s
 
       - name: Install reqs for ingest api
-        run: python -m pip install -r ingest_api/runtime/requirements.txt
+        run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
 
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,12 @@ jobs:
       - name: Integrations tests
         run: python -m pytest .github/workflows/tests/ -vv -s
 
+      - name: Install reqs for ingest api
+        run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
+
+      - name: Ingest unit tests
+        run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
+
       - name: Stop services
         run: docker compose stop
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,7 @@ jobs:
         run: python -m pytest .github/workflows/tests/ -vv -s
 
       - name: Install reqs for ingest api
-        run: python -m pip install -r ingest_api/runtime/requirements.txt
+        run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
 
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s

--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -288,7 +288,7 @@ def create_collection_extents_functions(cursor) -> None:
                     )
                 )
             )
-        WHERE collection.id=$1;
+        WHERE collections.id=$1;
     $function$
     ;
     """

--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -271,9 +271,9 @@ def create_collection_extents_functions(cursor) -> None:
     cursor.execute(sql.SQL(collection_temporal_extent_max_sql))
 
     update_collection_extents_max_sql = """
-    CREATE OR REPLACE FUNCTION dashboard.update_collection_extents_max(id text) RETURNS jsonb
+    CREATE OR REPLACE FUNCTION dashboard.update_collection_extents_max(id text) 
+    RETURNS void
     LANGUAGE sql
-    IMMUTABLE PARALLEL SAFE
     SET search_path TO 'pgstac', 'public'
     AS $function$
         UPDATE collections SET

--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -486,10 +486,13 @@ def handler(event, context):
                 print("Creating dashboard schema...")
                 create_dashboard_schema(cursor=cur, username=user_params["username"])
 
-                print(
-                    "Creating functions for summarizing default collection datetimes and cog_default statistics..."
-                )
+                print("Creating functions for summarizing collection datetimes...")
                 create_collection_summaries_functions(cursor=cur)
+
+                print(
+                    "Creating functions for setting the maximum end_datetime temporal extent of a collection..."
+                )
+                create_collection_extents_functions(cursor=cur)
 
     except Exception as e:
         print(f"Unable to bootstrap database with exception={e}")

--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -271,7 +271,7 @@ def create_collection_extents_functions(cursor) -> None:
     cursor.execute(sql.SQL(collection_temporal_extent_max_sql))
 
     update_collection_extents_max_sql = """
-    CREATE OR REPLACE FUNCTION dashboard.update_collection_extents_max(id text) 
+    CREATE OR REPLACE FUNCTION dashboard.update_collection_extents_max(id text)
     RETURNS void
     LANGUAGE sql
     SET search_path TO 'pgstac', 'public'

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -1,7 +1,7 @@
 # Waiting for https://github.com/stac-utils/stac-pydantic/pull/116 and 117
 Authlib==1.0.1
 ddbcereal==2.1.1
-fastapi>=0.75.1
+fastapi<=0.108.0
 fsspec==2023.3.0
 mangum>=0.15.0
 orjson>=3.6.8

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -9,6 +9,7 @@ psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.10.12
 pypgstac==0.7.4
+python-multipart==0.0.7
 requests>=2.27.1
 s3fs==2023.3.0
 stac-pydantic @ git+https://github.com/ividito/stac-pydantic.git@3f4cb381c85749bb4b15d1181179057ec0f51a94

--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -9,7 +9,6 @@ psycopg[binary,pool]>=3.0.15
 pydantic_ssm_settings>=0.2.0
 pydantic>=1.10.12
 pypgstac==0.7.4
-python-multipart==0.0.7
 requests>=2.27.1
 s3fs==2023.3.0
 stac-pydantic @ git+https://github.com/ividito/stac-pydantic.git@3f4cb381c85749bb4b15d1181179057ec0f51a94
@@ -17,3 +16,5 @@ xarray==2023.1.0
 xstac==1.1.0
 zarr==2.13.6
 boto3==1.24.59
+moto[dynamodb, ssm]>=4.0.9,<5.0
+httpx

--- a/ingest_api/runtime/requirements_dev.txt
+++ b/ingest_api/runtime/requirements_dev.txt
@@ -17,3 +17,5 @@ xarray==2023.1.0
 xstac==1.1.0
 zarr==2.13.6
 boto3==1.24.59
+moto[dynamodb, ssm]>=4.0.9,<5.0
+httpx

--- a/ingest_api/runtime/src/vedaloader.py
+++ b/ingest_api/runtime/src/vedaloader.py
@@ -20,30 +20,20 @@ class VEDALoader(Loader):
         STAC-conformant bbox and temporal extent."""
         with self.conn.cursor() as cur:
             with self.conn.transaction():
+
+                # First update the spatial and temporal extents for all item records for the collection
+                logger.info(f"Updating extents for collection: {collection_id}.")
+                cur.execute(
+                    "SELECT dashboard.update_collection_extents_max(%s)",
+                    (collection_id,),
+                )
+
+                # Next update default summaries which use the collection temporal extent for summaries of periodic items
                 logger.info(
                     f"Updating dashboard summaries for collection: {collection_id}."
                 )
                 cur.execute(
                     "SELECT dashboard.update_collection_default_summaries(%s)",
-                    (collection_id,),
-                )
-                logger.info(f"Updating extents for collection: {collection_id}.")
-                cur.execute(
-                    """
-                    UPDATE collections SET
-                    content = content ||
-                    jsonb_build_object(
-                        'extent', jsonb_build_object(
-                            'spatial', jsonb_build_object(
-                                'bbox', collection_bbox(collections.id)
-                            ),
-                            'temporal', jsonb_build_object(
-                                'interval', collection_temporal_extent(collections.id)
-                            )
-                        )
-                    )
-                    WHERE collections.id=%s;
-                    """,
                     (collection_id,),
                 )
 

--- a/ingest_api/runtime/tests/test_registration.py
+++ b/ingest_api/runtime/tests/test_registration.py
@@ -9,7 +9,6 @@ import pytest
 
 from fastapi.encoders import jsonable_encoder
 
-# from src.schemas import Ingestion
 
 if TYPE_CHECKING:
     from src import schemas, services
@@ -66,27 +65,3 @@ class TestList:
         assert json.loads(base64.b64decode(response.json()["next"])) == expected_next
         assert response.json()["items"] == jsonable_encoder(example_ingestions[:limit])
 
-    # def test_load_large_number(self):
-    #     ingestion_data = self.example_ingestion.dict()
-    #     visual_asset = ingestion_data["item"]["assets"]["visual"]
-    #     # todo: why does this need to be a float?
-    #     visual_asset["nodata"] = -3.4028234663852886e38
-    #     ingestion = Ingestion.parse_obj(ingestion_data)
-    #     self.mock_table.put_item(Item=ingestion.dynamodb_dict())
-
-    #     response = self.api_client.get(ingestion_endpoint)
-    #     actual = response.json()["items"]
-    #     expected = [json.loads(ingestion.json(by_alias=True))]
-
-    #     # first, check the nodata value
-    #     # value should match, format will not. isclose() will properly compare the values
-    #     assert isclose(
-    #         actual[0]["item"]["assets"]["visual"]["nodata"],
-    #         expected[0]["item"]["assets"]["visual"]["nodata"],
-    #         abs_tol=1,
-    #     )
-    #     expected[0]["item"]["assets"]["visual"]["nodata"] = actual[0]["item"]["assets"][
-    #         "visual"
-    #     ]["nodata"]
-    #     # second, check everything else
-    #     assert actual == expected

--- a/ingest_api/runtime/tests/test_registration.py
+++ b/ingest_api/runtime/tests/test_registration.py
@@ -1,11 +1,15 @@
 import base64
 import json
 from datetime import timedelta
-from math import isclose
+
+# from math import isclose
 from typing import TYPE_CHECKING, List
 
 import pytest
-from src.schemas import Ingestion
+
+from fastapi.encoders import jsonable_encoder
+
+# from src.schemas import Ingestion
 
 if TYPE_CHECKING:
     from src import schemas, services
@@ -39,11 +43,11 @@ class TestList:
 
     def test_simple_lookup(self):
         self.mock_table.put_item(Item=self.example_ingestion.dynamodb_dict())
-
+        ingestion = jsonable_encoder(self.example_ingestion)
         response = self.api_client.get(ingestion_endpoint)
         assert response.status_code == 200
         assert response.json() == {
-            "items": [json.loads(self.example_ingestion.json(by_alias=True))],
+            "items": [ingestion],
             "next": None,
         }
 
@@ -60,32 +64,29 @@ class TestList:
         response = self.api_client.get(ingestion_endpoint, params={"limit": limit})
         assert response.status_code == 200
         assert json.loads(base64.b64decode(response.json()["next"])) == expected_next
-        assert response.json()["items"] == [
-            json.loads(ingestion.json(by_alias=True))
-            for ingestion in example_ingestions[:limit]
-        ]
+        assert response.json()["items"] == jsonable_encoder(example_ingestions[:limit])
 
-    def test_load_large_number(self):
-        ingestion_data = self.example_ingestion.dict()
-        visual_asset = ingestion_data["item"]["assets"]["visual"]
-        # todo: why does this need to be a float?
-        visual_asset["nodata"] = -3.4028234663852886e38
-        ingestion = Ingestion.parse_obj(ingestion_data)
-        self.mock_table.put_item(Item=ingestion.dynamodb_dict())
+    # def test_load_large_number(self):
+    #     ingestion_data = self.example_ingestion.dict()
+    #     visual_asset = ingestion_data["item"]["assets"]["visual"]
+    #     # todo: why does this need to be a float?
+    #     visual_asset["nodata"] = -3.4028234663852886e38
+    #     ingestion = Ingestion.parse_obj(ingestion_data)
+    #     self.mock_table.put_item(Item=ingestion.dynamodb_dict())
 
-        response = self.api_client.get(ingestion_endpoint)
-        actual = response.json()["items"]
-        expected = [json.loads(ingestion.json(by_alias=True))]
+    #     response = self.api_client.get(ingestion_endpoint)
+    #     actual = response.json()["items"]
+    #     expected = [json.loads(ingestion.json(by_alias=True))]
 
-        # first, check the nodata value
-        # value should match, format will not. isclose() will properly compare the values
-        assert isclose(
-            actual[0]["item"]["assets"]["visual"]["nodata"],
-            expected[0]["item"]["assets"]["visual"]["nodata"],
-            abs_tol=1,
-        )
-        expected[0]["item"]["assets"]["visual"]["nodata"] = actual[0]["item"]["assets"][
-            "visual"
-        ]["nodata"]
-        # second, check everything else
-        assert actual == expected
+    #     # first, check the nodata value
+    #     # value should match, format will not. isclose() will properly compare the values
+    #     assert isclose(
+    #         actual[0]["item"]["assets"]["visual"]["nodata"],
+    #         expected[0]["item"]["assets"]["visual"]["nodata"],
+    #         abs_tol=1,
+    #     )
+    #     expected[0]["item"]["assets"]["visual"]["nodata"] = actual[0]["item"]["assets"][
+    #         "visual"
+    #     ]["nodata"]
+    #     # second, check everything else
+    #     assert actual == expected

--- a/ingest_api/runtime/tests/test_registration.py
+++ b/ingest_api/runtime/tests/test_registration.py
@@ -1,8 +1,6 @@
 import base64
 import json
 from datetime import timedelta
-
-# from math import isclose
 from typing import TYPE_CHECKING, List
 
 import pytest

--- a/ingest_api/runtime/tests/test_registration.py
+++ b/ingest_api/runtime/tests/test_registration.py
@@ -9,7 +9,6 @@ import pytest
 
 from fastapi.encoders import jsonable_encoder
 
-
 if TYPE_CHECKING:
     from src import schemas, services
 
@@ -64,4 +63,3 @@ class TestList:
         assert response.status_code == 200
         assert json.loads(base64.b64decode(response.json()["next"])) == expected_next
         assert response.json()["items"] == jsonable_encoder(example_ingestions[:limit])
-

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
         "fastapi",
-        "moto==4.2.12",
+        "moto[dynamodb, ssm]>=4.0.9,<5.0",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
         "fastapi",
-        "moto",
+        "moto==4.2.12",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extra_reqs = {
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
         "fastapi",
-        "moto[dynamodb, ssm]>=4.0.9,<5.0",
+        "moto",
     ],
 }
 


### PR DESCRIPTION
## What
- Improve veda loader method that updates the summaries and extents of all items in a collection with a new `collection_temporal_extent_max` function that includes the maximum item `end_datetime` which is significantly different from an item's nominal `datetime` in collections of items that represent an entire year or range or dates.
- Removes ingest api large number test that is no longer needed because we no longer convert json values for the DDB schema.
- Pins fastapi at for ingest api tests (tech debt). Note that python-multipart is pinned at the new and secure version so it is still OK for us to use older versions of fastapi and starlette for now.
- Sets moto version to fix tests.

> **Note**
This requires incrementing `VEDA_DB_SCHEMA_VERSION` to cause the dashboard schema update to run so I am making it a breaking change.

## How tested
I removed the latest date from the geoglam collection's temporal extent _and_ datetime summaries then ingested a single item to /ingestions which triggered both the summaries and extent functions to be executed. Verified in dev.openveda.cloud/api/stac/collections/geoglam.
