### PR TITLE
chore: run ingest tests with coverage in local test script

### DIFF
--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -30,3 +30,6 @@ docker exec veda.db /tmp/scripts/bin/load-data.sh
 
 # Run tests
 python -m pytest .github/workflows/tests/ -vv -s
+
+# Run ingest unit tests
+NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest --cov=ingest_api/runtime/src ingest_api/runtime/tests/ -vv -s

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extra_reqs = {
     "test": [
         "pytest",
         "pytest-asyncio",
+        "pytest-cov",
         "httpx==0.23.3",
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",


### PR DESCRIPTION
### Issue

#348 

### What?

The run-local-tests.sh script runs the integration tests. This adds a run of the ingest api unit tests and generates a coverage report

### Why?

- Instead of just manually documenting the existing tests, it would be beneficial to see what the current coverage level of those tests are and determine which areas should have more coverage.

Current baseline: 55% coverage
Output from running `./scripts/run-local-tests.sh`
```
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.9.9, pytest-7.4.4, pluggy-1.4.0 -- /Users/stephenkilbourn/.pyenv/versions/3.9.9/bin/python
cachedir: .pytest_cache
rootdir: /Users/stephenkilbourn/e84/veda/veda-backend
plugins: cov-5.0.0, anyio-4.3.0, time-machine-2.14.0
collected 6 items

.github/workflows/tests/test_raster.py::test_raster_api PASSED
.github/workflows/tests/test_raster.py::test_mosaic_api PASSED
.github/workflows/tests/test_raster.py::test_mosaic_search PASSED
.github/workflows/tests/test_raster.py::test_item PASSED
.github/workflows/tests/test_stac.py::test_stac_api PASSED
.github/workflows/tests/test_stac.py::test_stac_to_raster PASSED

===================================================================================== 6 passed in 7.34s =====================================================================================
==================================================================================== test session starts ====================================================================================
platform darwin -- Python 3.9.9, pytest-7.4.4, pluggy-1.4.0 -- /Users/stephenkilbourn/.pyenv/versions/3.9.9/bin/python
cachedir: .pytest_cache
rootdir: /Users/stephenkilbourn/e84/veda/veda-backend
plugins: cov-5.0.0, anyio-4.3.0, time-machine-2.14.0
collected 2 items

ingest_api/runtime/tests/test_registration.py::TestList::test_simple_lookup PASSED
ingest_api/runtime/tests/test_registration.py::TestList::test_next_response PASSED

---------- coverage: platform darwin, python 3.9.9-final-0 -----------
Name                                             Stmts   Miss  Cover
--------------------------------------------------------------------
ingest_api/runtime/src/__init__.py                   0      0   100%
ingest_api/runtime/src/auth.py                      51     30    41%
ingest_api/runtime/src/collection_publisher.py      23     12    48%
ingest_api/runtime/src/config.py                    19      1    95%
ingest_api/runtime/src/dependencies.py              18      6    67%
ingest_api/runtime/src/doc.py                        1      0   100%
ingest_api/runtime/src/ingestor.py                  47     47     0%
ingest_api/runtime/src/main.py                      70     29    59%
ingest_api/runtime/src/schema_helpers.py            28      8    71%
ingest_api/runtime/src/schemas.py                  121     27    78%
ingest_api/runtime/src/services.py                  25      7    72%
ingest_api/runtime/src/utils.py                     41     17    59%
ingest_api/runtime/src/validators.py                45     33    27%
ingest_api/runtime/src/vedaloader.py                20     13    35%
--------------------------------------------------------------------
TOTAL                                              509    230    55%


===================================================================================== 2 passed in 3.04s =====================================================================================
Tests passed, no need to collect logs.
Removing test stack...
```

### Testing?

- Relevant testing details

