### PR TITLE
fix(stac-api): next link and trailing slash bug in stac api url

### DIFF
--- a/config.py
+++ b/config.py
@@ -131,7 +131,7 @@ class vedaAppSettings(BaseSettings):
     def get_stac_catalog_url(self) -> Optional[str]:
         """Infer stac catalog url based on whether the app is configured to deploy the catalog to a custom subdomain or to a cloudfront route"""
         if self.veda_custom_host and self.veda_stac_root_path:
-            return f"https://{veda_app_settings.veda_custom_host}{veda_app_settings.veda_stac_root_path}/"
+            return f"https://{veda_app_settings.veda_custom_host}{veda_app_settings.veda_stac_root_path}"
         if (
             self.veda_domain_create_custom_subdomains
             and self.veda_domain_hosted_zone_name

--- a/stac_api/runtime/handler.py
+++ b/stac_api/runtime/handler.py
@@ -12,7 +12,7 @@ settings = ApiSettings()
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
 
-handler = Mangum(app, lifespan="auto", api_gateway_base_path=app.root_path)
+handler = Mangum(app, lifespan="auto")
 
 # Add tracing
 handler.__name__ = "handler"  # tracer requires __name__ to be set


### PR DESCRIPTION
## What
Fix problem in which a stac-fastapi deployed behind a proxy (i.e. `customdomain.com`) with a custom root path (i.e. `/api/stac`)
- Fixed: API does not properly resolve `customdomain.com/api/stac` -> `customdomain.com/api/stac/`
- Fixed: API does not properly use custom root path in next links of paginated responses `customdomain.com/api/stac/...` links are returned as `customdomain.com/...` without the custom root path. 

The correction is to remove the gateway configuration from the Mangum ASGI handler for the stac-api handler.

### Refs
- [Fastapi behind a proxy](https://fastapi.tiangolo.com/advanced/behind-a-proxy/#proxy-with-a-stripped-path-prefix)
- [Mangum configuring an adaptar instance with api_gateway_base_path](https://mangum.io/adapter/#configuring-an-adapter-instance_) pattern that we use and need for titiler/raster-api and ingest-api

### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/343

### Testing?

- I deployed this change manually to the dev veda-backend stack and confirmed that the stac-api url is properly resolved and that the next links now properly include the root path.

