### PR TITLE
fix: update get_username function 

### DIFF
--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -58,6 +58,8 @@ def validated_token(
 def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
     logger.info(f"\nToken {token}")
     result = token["username"] if "username" in token else token.get("sub", None)
+    if result is None:
+        raise KeyError(f"Neither 'username' nor 'sub' found in the token: {token}.")
     return result
 
 

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -33,7 +33,7 @@ def validated_token(
             jwks_client.get_signing_key_from_jwt(token_str).key,
             algorithms=["RS256"],
         )
-        logger.info(f"\Decoded token {token}")
+        logger.info(f"\nDecoded token {token}")
     except jwt.exceptions.InvalidTokenError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -58,8 +58,6 @@ def validated_token(
 def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
     logger.info(f"\nToken {token}")
     result = token["username"] if "username" in token else token.get("sub", None)
-    if result is None:
-        raise KeyError(f"Neither 'username' nor 'sub' found in the token: {token}.")
     return result
 
 

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -26,12 +26,14 @@ def validated_token(
     required_scopes: security.SecurityScopes,
 ) -> Dict:
     # Parse & validate token
+    logger.info(f"\nToken String {token_str}")
     try:
         token = jwt.decode(
             token_str,
             jwks_client.get_signing_key_from_jwt(token_str).key,
             algorithms=["RS256"],
         )
+        logger.info(f"\Decoded token {token}")
     except jwt.exceptions.InvalidTokenError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -53,8 +55,10 @@ def validated_token(
     return token
 
 
-def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]):
-    return token["username"]
+def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
+    logger.info(f"\nToken {token}")
+    result = token["username"] if "username" in token else token.get("sub", None)
+    return result
 
 
 def _get_secret_hash(username: str, client_id: str, client_secret: str) -> str:

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -69,6 +69,8 @@ async def enqueue_ingestion(
     """
     Queues a STAC item for ingestion.
     """
+
+    logger.info(f"\nUsername {username}")
     return schemas.Ingestion(
         id=item.id,
         created_by=username,


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-data-airflow/issues/134
https://github.com/NASA-IMPACT/veda-backend/issues/347

### What?

- Update get_username to fall back on `sub` if `username` doesn't exist in token
- Added some more logging statements to make debugging easier in the future

### Why?

- This fix is to enable a successful workflows API run since the workflow API passes a token to backend API and it's currently erroring
- Also, `sub` is a more definitive identifier because it represents a unique identifier compared to `username` 

### Testing?

- Relevant testing details

