### PR TITLE
fix: cast sub as str

### DIFF
--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -33,7 +33,6 @@ def validated_token(
             jwks_client.get_signing_key_from_jwt(token_str).key,
             algorithms=["RS256"],
         )
-        logger.info(f"\nDecoded token {token}")
     except jwt.exceptions.InvalidTokenError as e:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -57,7 +56,7 @@ def validated_token(
 
 def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
     logger.info(f"\nToken {token}")
-    result = token["username"] if "username" in token else token.get("sub", None)
+    result = token["username"] if "username" in token else str(token.get("sub", None))
     return result
 
 

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -56,7 +56,7 @@ def validated_token(
 
 def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
     logger.info(f"\nToken {token}")
-    result = token["username"] if "username" in token else str(token.get("sub", None))
+    result = token["username"] if "username" in token else str(token.get("sub"))
     return result
 
 

--- a/ingest_api/runtime/src/auth.py
+++ b/ingest_api/runtime/src/auth.py
@@ -55,7 +55,6 @@ def validated_token(
 
 
 def get_username(token: Annotated[Dict[Any, Any], Depends(validated_token)]) -> str:
-    logger.info(f"\nToken {token}")
     result = token["username"] if "username" in token else str(token.get("sub"))
     return result
 


### PR DESCRIPTION
### Issue

Link to relevant GitHub issue

### What?

- Cast `sub` as `str` and remove default `None` since that will be cast as `str` which we want to avoid
```
>>> token = { }
>>> x = token.get("sub", None)
>>> str(x)
'None'
>>> exit()
```

### Why?

- We were receiving this error when trying to kick off a `/dataset/publish/` workflow
`1 validation error for Ingestion\ncreated_by\n  str type expected (type=type_error.str)` and, to be safe, we are casting `sub` as `str`

### Testing?

- Locally deployed on dev and ran `/dataset/publish/` successfully https://4e76fa52-1de6-41a5-b364-691fb1cc69f4.c18.us-west-2.airflow.amazonaws.com/dags/veda_ingest_raster/graph?run_id=0767fd24-461d-481f-85eb-2ebb4662d144_617296f2-18e1-4711-9961-8a542bb8958b_0&execution_date=2024-05-02+19%3A54%3A13.422305%2B00%3A00

