### PR TITLE
fix(ingest): default empty string for root path in ingest api construct

### DIFF
--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -51,7 +51,7 @@ class IngestorConfig(BaseSettings):
         description="URL of Raster API used to serve asset tiles"
     )
 
-    ingest_root_path: str = Field(description="Root path for ingest API")
+    ingest_root_path: str = Field("", description="Root path for ingest API")
     custom_host: Optional[str] = Field(description="Custom host name")
 
     class Config:

--- a/ingest_api/runtime/src/config.py
+++ b/ingest_api/runtime/src/config.py
@@ -28,7 +28,7 @@ class Settings(BaseSettings):
     )
     client_id: str = Field(description="The Cognito APP client ID")
     client_secret: str = Field("", description="The Cognito APP client secret")
-    root_path: Optional[str] = Field(description="Root path of API")
+    root_path: Optional[str] = None
     stage: Optional[str] = Field(description="API stage")
 
     @property


### PR DESCRIPTION
### What?
- Allow ingest-api to be deployed without a custom root path by setting the default config for fastapi root path parameter to None.

### Why?
- When the ingest API is deployed to a stack without a cloud front and custom host it should not apply an additional root path.

### How tested
Deployed to a test branch using a custom subdomain instead of a cloudfront with custom root path.


