### PR TITLE
fix: backend monitoring changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,6 +122,7 @@ db_security_group = database.db_security_group
 
 # ingestor config requires references to other resources, but can be shared between ingest api and bulk ingestor
 ingestor_config = ingest_config(
+    stage=veda_app_settings.stage_name(),
     stac_db_security_group_id=db_security_group.security_group_id,
     stac_api_url=stac_api.stac_api.url,
     raster_api_url=raster_api.raster_api.url,

--- a/ingest_api/runtime/handler.py
+++ b/ingest_api/runtime/handler.py
@@ -4,5 +4,14 @@ Entrypoint for Lambda execution.
 
 from mangum import Mangum
 from src.main import app
+from src.monitoring import logger, metrics, tracer
 
 handler = Mangum(app, lifespan="off", api_gateway_base_path=app.root_path)
+
+# Add tracing
+handler.__name__ = "handler"  # tracer requires __name__ to be set
+handler = tracer.capture_lambda_handler(handler)
+# Add logging
+handler = logger.inject_lambda_context(handler, clear_state=True)
+# Add metrics last to properly flush metrics.
+handler = metrics.log_metrics(handler, capture_cold_start_metric=True)

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -34,13 +34,13 @@ app = FastAPI(
     },
 )
 
-router = APIRouter(route_class=LoggerRouteHandler)
+app.router.route_class = LoggerRouteHandler
 
 collection_publisher = CollectionPublisher()
 item_publisher = ItemPublisher()
 
 
-@router.get(
+@app.get(
     "/ingestions", response_model=schemas.ListIngestionResponse, tags=["Ingestion"]
 )
 async def list_ingestions(
@@ -55,7 +55,7 @@ async def list_ingestions(
     )
 
 
-@router.post(
+@app.post(
     "/ingestions",
     response_model=schemas.Ingestion,
     tags=["Ingestion"],
@@ -79,7 +79,7 @@ async def enqueue_ingestion(
     ).enqueue(db)
 
 
-@router.get(
+@app.get(
     "/ingestions/{ingestion_id}",
     response_model=schemas.Ingestion,
     tags=["Ingestion"],
@@ -93,7 +93,7 @@ def get_ingestion(
     return ingestion
 
 
-@router.patch(
+@app.patch(
     "/ingestions/{ingestion_id}",
     response_model=schemas.Ingestion,
     tags=["Ingestion"],
@@ -110,7 +110,7 @@ def update_ingestion(
     return updated_item.save(db)
 
 
-@router.delete(
+@app.delete(
     "/ingestions/{ingestion_id}",
     response_model=schemas.Ingestion,
     tags=["Ingestion"],
@@ -132,7 +132,7 @@ def cancel_ingestion(
     return ingestion.cancel(db)
 
 
-@router.post(
+@app.post(
     "/collections",
     tags=["Collection"],
     status_code=201,
@@ -153,7 +153,7 @@ def publish_collection(collection: schemas.DashboardCollection):
         )
 
 
-@router.delete(
+@app.delete(
     "/collections/{collection_id}",
     tags=["Collection"],
     dependencies=[Depends(auth.validated_token)],
@@ -170,7 +170,7 @@ def delete_collection(collection_id: str):
         raise HTTPException(status_code=400, detail=(f"{e}"))
 
 
-@router.post(
+@app.post(
     "/items",
     tags=["Items"],
     status_code=201,
@@ -191,7 +191,7 @@ def publish_item(item: schemas.Item):
         )
 
 
-@router.post("/token", tags=["Auth"], response_model=schemas.AuthResponse)
+@app.post("/token", tags=["Auth"], response_model=schemas.AuthResponse)
 async def get_token(
     form_data: OAuth2PasswordRequestForm = Depends(),
 ) -> Dict:
@@ -213,7 +213,7 @@ async def get_token(
         )
 
 
-@router.get("/auth/me", tags=["Auth"])
+@app.get("/auth/me", tags=["Auth"])
 def who_am_i(claims=Depends(auth.validated_token)):
     """
     Return claims for the provided JWT
@@ -260,6 +260,3 @@ async def general_exception_handler(request, err):
     metrics.add_metric(name="UnhandledExceptions", unit=MetricUnit.Count, value=1)
     logger.exception("Unhandled exception")
     return JSONResponse(status_code=500, content={"detail": "Internal Server Error"})
-
-
-app.include_router(router)

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -10,7 +10,7 @@ from src.config import settings
 from src.doc import DESCRIPTION
 from src.monitoring import LoggerRouteHandler, logger, metrics, tracer
 
-from fastapi import APIRouter, Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from fastapi.security import OAuth2PasswordRequestForm

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -3,11 +3,10 @@ from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
+from src.config import settings
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
-
-from src.config import settings
 
 logger: Logger = Logger(
     service="ingest-api", namespace=f"veda-backend-{settings.stage}"

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -7,8 +7,10 @@ from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
 
-logger: Logger = Logger(service="raster-api", namespace="veda-backend")
-metrics: Metrics = Metrics(service="raster-api", namespace="veda-backend")
+from src.config import settings
+
+logger: Logger = Logger(service="ingest-api", namespace=f"veda-backend-{settings.stage}")
+metrics: Metrics = Metrics(service="ingest-api", namespace=f"veda-backend-{settings.stage}")
 tracer: Tracer = Tracer()
 
 

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -44,7 +44,7 @@ class LoggerRouteHandler(APIRoute):
                 unit=MetricUnit.Count,
                 value=1,
                 default_dimensions=metrics.default_dimensions,
-                namespace="veda-backend"
+                namespace="veda-backend",
             ) as metric:
                 metric.add_dimension(
                     name="route", value=f"{request.method} {self.path}"

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -1,6 +1,6 @@
 """Observability utils"""
-from typing import Callable
 import json
+from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -9,8 +9,12 @@ from fastapi.routing import APIRoute
 
 from src.config import settings
 
-logger: Logger = Logger(service="ingest-api", namespace=f"veda-backend-{settings.stage}")
-metrics: Metrics = Metrics(service="ingest-api", namespace=f"veda-backend-{settings.stage}")
+logger: Logger = Logger(
+    service="ingest-api", namespace=f"veda-backend-{settings.stage}"
+)
+metrics: Metrics = Metrics(
+    service="ingest-api", namespace=f"veda-backend-{settings.stage}"
+)
 tracer: Tracer = Tracer()
 
 

--- a/ingest_api/runtime/src/monitoring.py
+++ b/ingest_api/runtime/src/monitoring.py
@@ -9,12 +9,8 @@ from src.config import settings
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
 
-logger: Logger = Logger(
-    service="ingest-api", namespace="veda-backend"
-)
-metrics: Metrics = Metrics(
-    service="ingest-api", namespace="veda-backend"
-)
+logger: Logger = Logger(service="ingest-api", namespace="veda-backend")
+metrics: Metrics = Metrics(service="ingest-api", namespace="veda-backend")
 metrics.set_default_dimensions(environment=settings.stage)
 tracer: Tracer = Tracer()
 
@@ -43,9 +39,7 @@ class LoggerRouteHandler(APIRoute):
             logger.append_keys(fastapi=ctx)
             logger.info("Received request")
             metrics.add_metric(
-                name="/".join(
-                    str(request.url.path).split("/")[:2]
-                ),  # enough detail to capture search IDs, but not individual tile coords
+                name=self.path,
                 unit=MetricUnit.Count,
                 value=1,
             )

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -80,6 +80,10 @@ class RasterApiLambdaConstruct(Construct):
             "VEDA_RASTER_ROOT_PATH", veda_raster_settings.raster_root_path
         )
 
+        veda_raster_function.add_environment(
+            "VEDA_RASTER_STAGE", stage
+        )
+
         # Optional AWS S3 requester pays global setting
         if veda_raster_settings.raster_aws_request_payer:
             veda_raster_function.add_environment(

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -80,9 +80,7 @@ class RasterApiLambdaConstruct(Construct):
             "VEDA_RASTER_ROOT_PATH", veda_raster_settings.raster_root_path
         )
 
-        veda_raster_function.add_environment(
-            "VEDA_RASTER_STAGE", stage
-        )
+        veda_raster_function.add_environment("VEDA_RASTER_STAGE", stage)
 
         # Optional AWS S3 requester pays global setting
         if veda_raster_settings.raster_aws_request_payer:

--- a/raster_api/runtime/src/config.py
+++ b/raster_api/runtime/src/config.py
@@ -57,6 +57,7 @@ class ApiSettings(BaseSettings):
     cachecontrol: str = "public, max-age=3600"
     debug: bool = False
     root_path: Optional[str] = None
+    stage: Optional[str] = None
 
     # MosaicTiler settings
     enable_mosaic_search: bool = False

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -11,13 +11,17 @@ from src.config import ApiSettings
 
 settings = ApiSettings()
 
-logger: Logger = Logger(service="raster-api", namespace=f"veda-backend-{settings.stage}")
-metrics: Metrics = Metrics(service="raster-api", namespace=f"veda-backend-{settings.stage}")
+logger: Logger = Logger(
+    service="raster-api", namespace=f"veda-backend-{settings.stage}"
+)
+metrics: Metrics = Metrics(
+    service="raster-api", namespace=f"veda-backend-{settings.stage}"
+)
 tracer: Tracer = Tracer()
 
 
 class LoggerRouteHandler(APIRoute):
-    """Extension of base APIRoute to add context to log statements, as well as record usage metricss"""
+    """Extension of base APIRoute to add context to log statements, as well as record usage metrics"""
 
     def get_route_handler(self) -> Callable:
         """Overide route handler method to add logs, metrics, tracing"""
@@ -27,15 +31,14 @@ class LoggerRouteHandler(APIRoute):
             # Add fastapi context to logs
             ctx = {
                 "path": request.url.path,
+                "path_params": request.path_params,
                 "route": self.path,
                 "method": request.method,
             }
             logger.append_keys(fastapi=ctx)
             logger.info("Received request")
             metrics.add_metric(
-                name="/".join(
-                    str(request.url.path).split("/")[:2]
-                ),  # enough detail to capture search IDs, but not individual tile coords
+                name=self.path,  # enough detail to capture search IDs, but not individual tile coords
                 unit=MetricUnit.Count,
                 value=1,
             )

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -47,7 +47,7 @@ class LoggerRouteHandler(APIRoute):
                 unit=MetricUnit.Count,
                 value=1,
                 default_dimensions=metrics.default_dimensions,
-                namespace="veda-backend"
+                namespace="veda-backend",
             ) as metric:
                 metric.add_dimension(
                     name="route", value=f"{request.method} {self.path}"

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -1,6 +1,6 @@
 """Observability utils"""
-from typing import Callable
 import json
+from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -7,8 +7,12 @@ from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
 
-logger: Logger = Logger(service="raster-api", namespace="veda-backend")
-metrics: Metrics = Metrics(service="raster-api", namespace="veda-backend")
+from src.config import ApiSettings
+
+settings = ApiSettings()
+
+logger: Logger = Logger(service="raster-api", namespace=f"veda-backend-{settings.stage}")
+metrics: Metrics = Metrics(service="raster-api", namespace=f"veda-backend-{settings.stage}")
 tracer: Tracer = Tracer()
 
 

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -11,12 +11,8 @@ from fastapi.routing import APIRoute
 
 settings = ApiSettings()
 
-logger: Logger = Logger(
-    service="raster-api", namespace="veda-backend"
-)
-metrics: Metrics = Metrics(
-    service="raster-api", namespace="veda-backend"
-)
+logger: Logger = Logger(service="raster-api", namespace="veda-backend")
+metrics: Metrics = Metrics(service="raster-api", namespace="veda-backend")
 metrics.set_default_dimensions(environment=settings.stage)
 tracer: Tracer = Tracer()
 
@@ -47,7 +43,7 @@ class LoggerRouteHandler(APIRoute):
             logger.info("Received request")
 
             metrics.add_metric(
-                name=self.path, 
+                name=self.path,
                 unit=MetricUnit.Count,
                 value=1,
             )

--- a/raster_api/runtime/src/monitoring.py
+++ b/raster_api/runtime/src/monitoring.py
@@ -3,11 +3,10 @@ from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
+from src.config import ApiSettings
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
-
-from src.config import ApiSettings
 
 settings = ApiSettings()
 

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -84,9 +84,7 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_ROOT_PATH", veda_stac_settings.stac_root_path
         )
 
-        lambda_function.add_environment(
-            "VEDA_STAC_STAGE", stage
-        )
+        lambda_function.add_environment("VEDA_STAC_STAGE", stage)
 
         integration_kwargs = dict(handler=lambda_function)
         if veda_stac_settings.custom_host:

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -84,6 +84,10 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_ROOT_PATH", veda_stac_settings.stac_root_path
         )
 
+        lambda_function.add_environment(
+            "VEDA_STAC_STAGE", stage
+        )
+
         integration_kwargs = dict(handler=lambda_function)
         if veda_stac_settings.custom_host:
             integration_kwargs[

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -49,7 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
-    router=APIRouter(route_class=LoggerRouteHandler)
+    router=APIRouter(route_class=LoggerRouteHandler),
 )
 app = api.app
 

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -8,7 +8,7 @@ from src.config import get_request_model as GETModel
 from src.config import post_request_model as POSTModel
 from src.extension import TiTilerExtension
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 from starlette.middleware.cors import CORSMiddleware
@@ -19,7 +19,7 @@ from starlette_cramjam.middleware import CompressionMiddleware
 
 from .api import VedaStacApi
 from .core import VedaCrudClient
-from .monitoring import logger, metrics, tracer
+from .monitoring import LoggerRouteHandler, logger, metrics, tracer
 
 try:
     from importlib.resources import files as resources_files  # type: ignore
@@ -49,6 +49,7 @@ api = VedaStacApi(
     search_post_request_model=POSTModel,
     response_class=ORJSONResponse,
     middlewares=[CompressionMiddleware],
+    router=APIRouter(route_class=LoggerRouteHandler)
 )
 app = api.app
 

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -56,6 +56,7 @@ class _ApiSettings(pydantic.BaseSettings):
     debug: bool = False
     root_path: Optional[str] = None
     pgstac_secret_arn: Optional[str]
+    stage: Optional[str] = None
 
     @pydantic.validator("cors_origins")
     def parse_cors_origin(cls, v):

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -12,9 +12,7 @@ from fastapi.routing import APIRoute
 settings = ApiSettings()
 
 logger: Logger = Logger(service="stac-api", namespace="veda-backend")
-metrics: Metrics = Metrics(
-    service="stac-api", namespace="veda-backend"
-)
+metrics: Metrics = Metrics(service="stac-api", namespace="veda-backend")
 metrics.set_default_dimensions(environment=settings.stage)
 tracer: Tracer = Tracer()
 
@@ -25,7 +23,7 @@ class LoggerRouteHandler(APIRoute):
     def get_route_handler(self) -> Callable:
         """Overide route handler method to add logs, metrics, tracing"""
         original_route_handler = super().get_route_handler()
-        
+
         async def route_handler(request: Request) -> Response:
             # Add fastapi context to logs
             body = await request.body()

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -47,7 +47,7 @@ class LoggerRouteHandler(APIRoute):
                 unit=MetricUnit.Count,
                 value=1,
                 default_dimensions=metrics.default_dimensions,
-                namespace="veda-backend"
+                namespace="veda-backend",
             ) as metric:
                 metric.add_dimension(
                     name="route", value=f"{request.method} {self.path}"

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -1,6 +1,6 @@
 """Observability utils"""
-from typing import Callable
 import json
+from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -12,12 +12,14 @@ from src.config import ApiSettings
 settings = ApiSettings()
 
 logger: Logger = Logger(service="stac-api", namespace=f"veda-backend-{settings.stage}")
-metrics: Metrics = Metrics(service="stac-api", namespace=f"veda-backend-{settings.stage}")
+metrics: Metrics = Metrics(
+    service="stac-api", namespace=f"veda-backend-{settings.stage}"
+)
 tracer: Tracer = Tracer()
 
 
 class LoggerRouteHandler(APIRoute):
-    """Extension of base APIRoute to add context to log statements, as well as record usage metricss"""
+    """Extension of base APIRoute to add context to log statements, as well as record usage metrics"""
 
     def get_route_handler(self) -> Callable:
         """Overide route handler method to add logs, metrics, tracing"""
@@ -27,7 +29,7 @@ class LoggerRouteHandler(APIRoute):
             # Add fastapi context to logs
             ctx = {
                 "path": request.url.path,
-                "path_params":request.path_params,
+                "path_params": request.path_params,
                 "route": self.path,
                 "method": request.method,
             }

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -2,7 +2,7 @@
 import json
 from typing import Callable
 
-from aws_lambda_powertools import Logger, Metrics, Tracer
+from aws_lambda_powertools import Logger, Metrics, Tracer, single_metric
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
 from src.config import ApiSettings
 
@@ -12,8 +12,8 @@ from fastapi.routing import APIRoute
 settings = ApiSettings()
 
 logger: Logger = Logger(service="stac-api", namespace="veda-backend")
-metrics: Metrics = Metrics(service="stac-api", namespace="veda-backend")
-metrics.set_default_dimensions(environment=settings.stage)
+metrics: Metrics = Metrics(namespace="veda-backend")
+metrics.set_default_dimensions(environment=settings.stage, service="stac-api")
 tracer: Tracer = Tracer()
 
 
@@ -42,11 +42,17 @@ class LoggerRouteHandler(APIRoute):
             logger.append_keys(fastapi=ctx)
             logger.info("Received request")
 
-            metrics.add_metric(
-                name=self.path,
+            with single_metric(
+                name="RequestCount",
                 unit=MetricUnit.Count,
                 value=1,
-            )
+                default_dimensions=metrics.default_dimensions,
+                namespace="veda-backend"
+            ) as metric:
+                metric.add_dimension(
+                    name="route", value=f"{request.method} {self.path}"
+                )
+
             tracer.put_annotation(key="path", value=request.url.path)
             tracer.capture_method(original_route_handler)(request)
             return await original_route_handler(request)

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -3,11 +3,10 @@ from typing import Callable
 
 from aws_lambda_powertools import Logger, Metrics, Tracer
 from aws_lambda_powertools.metrics import MetricUnit  # noqa: F401
+from src.config import ApiSettings
 
 from fastapi import Request, Response
 from fastapi.routing import APIRoute
-
-from src.config import ApiSettings
 
 settings = ApiSettings()
 


### PR DESCRIPTION
Changes to observability in backend APIs:

- Include monitoring for STAC API endpoints
- service dimension change for ingest api (incorrectly had "raster-api"), add monitoring to ingest handler
- include path params and post body in logs
- include stage dimension in metrics to distinguish between instances (i.e. dev, staging, etc.)
- include metrics for each api path (i.e. collections/, collections/{collection_id}, mosaic/register, etc.

## Testing

- deployed to `monitor` veda-backend stack and created tables in Grafana. See[ ticket](https://github.com/NASA-IMPACT/veda-backend/issues/349) for details. 
- Confirmed logs and metrics are being sent for raster, stac and ingest APIs