### PR TITLE
feat: enable cloudfront logging

### DIFF
--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -55,6 +55,7 @@ class CloudfrontDistributionConstruct(Construct):
                     cache_policy=cf.CachePolicy.CACHING_DISABLED,
                 ),
                 certificate=domain_cert,
+                enable_logging=True,
                 domain_names=[f"{stage}.{veda_route_settings.domain_hosted_zone_name}"]
                 if veda_route_settings.domain_hosted_zone_name
                 else None,


### PR DESCRIPTION
### Issue

[Link to relevant GitHub issue](https://github.com/NASA-IMPACT/veda-architecture/issues/431)

### What?

- Enable logging on the cloudfront distribution. Setting `enable_logging` to true will create an S3 bucket to write logs to with the necessary permissions for cloudfront to successfully send logs. 

### Why?

- Best practices

### Testing?

- Deployed to UAH dev and MCP test

