### PR TITLE
fix: make data access role optional in ingestor

### DIFF
--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -41,8 +41,8 @@ class IngestorConfig(BaseSettings):
         description="ID of Security Group used by pgSTAC DB"
     )
 
-    raster_data_access_role_arn: AwsArn = Field(  # type: ignore
-        description="ARN of AWS Role used to validate access to S3 data"
+    raster_data_access_role_arn: Optional[AwsArn] = Field(  # type: ignore
+        None, description="ARN of AWS Role used to validate access to S3 data"
     )
 
     stac_api_url: str = Field(description="URL of STAC API used to serve STAC Items")


### PR DESCRIPTION
### Issue

Data access role arn is optional in raster API, but ingestor makes it required, which doesn't make sense.

### What?

- Made raster_data_access_role_arn env var optional

### Why?

- Shouldn't be required

### Testing?

- Relevant testing details

