### PR TITLE
chore: Add rio-tiler version in raster API 

### DIFF
--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -7,6 +7,7 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
+    "rio-tiler==6.5.0",
     "titiler.pgstac==0.8.3",
     "titiler.core>=0.15.5,<0.16",
     "titiler.mosaic>=0.15.5,<0.16",


### PR DESCRIPTION
### Issue
Added latest version of rio-tiler (recorded as stable [here](https://github.com/US-GHG-Center/ghgc-backend/issues/72) ) 
 in raster API.

### What?

- Added version `6.5.0` of `rio-tiler` in raster API

### Why?

GHGC is preparing to deploy all VEDA dependencies through a common repository [`veda-deploy`](https://github.com/NASA-IMPACT/veda-deploy). Some of the forked repos in GHGC were ahead of VEDA and to reflect those changes, the version of `rio-tiler` is being upgraded.

