### PR TITLE
fix: ingestor role to have s3 access

### DIFF
--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -1,5 +1,5 @@
 from getpass import getuser
-from typing import Optional
+from typing import Optional, List
 
 import aws_cdk
 from pydantic import AnyHttpUrl, BaseSettings, Field, constr
@@ -8,6 +8,15 @@ AwsArn = constr(regex=r"^arn:aws:iam::\d{12}:role/.+")
 
 
 class IngestorConfig(BaseSettings):
+    # S3 bucket names where TiTiler could do HEAD and GET Requests
+    # specific private and public buckets MUST be added if you want to use s3:// urls
+    # You can whitelist all bucket by setting `*`.
+    # ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-arn-format.html
+    buckets: List = ["*"]
+
+    # S3 key pattern to limit the access to specific items (e.g: "my_data/*.tif")
+    key: str = "*"
+
     stage: str = Field(
         description=" ".join(
             [

--- a/ingest_api/infrastructure/config.py
+++ b/ingest_api/infrastructure/config.py
@@ -1,5 +1,5 @@
 from getpass import getuser
-from typing import Optional, List
+from typing import List, Optional
 
 import aws_cdk
 from pydantic import AnyHttpUrl, BaseSettings, Field, constr

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -77,6 +77,14 @@ class ApiConstruct(Construct):
 
         # create lambda
         self.api_lambda = self.build_api_lambda(**build_api_lambda_params)
+        self.api_lambda.add_to_role_policy(
+            iam.PolicyStatement(
+                actions=["s3:GetObject"],
+                resources=[
+                    f"arn:aws:s3:::{bucket}/{config.key}" for bucket in config.buckets
+                ],
+            )
+        )
 
         # create API
         self.api: aws_apigatewayv2_alpha.HttpApi = self.build_api(


### PR DESCRIPTION
### What?

When an external assume role hasn't been provided, the ingestor doesn't have access to any s3 bucket/keys causing all the `/ingestions` requests to fail because of the "Asset not accessible" validation error.
 
This PR fixes this by using the same bucket/key configuration (can also be passed via `VEDA_BUCKETS` and `VEDA_KEY` env var) that the raster API uses.

### Why?

- The ingestor should have the same s3 permissions as the raster API to validate if an asset is accessible from the raster api.


