### PR TITLE
fix: allow extra fields in collection links to support extensions

### DIFF
--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -7,7 +7,14 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import src.validators as validators
-from pydantic import BaseModel, Field, Json, PositiveInt, error_wrappers, validator
+from pydantic import (
+    BaseModel,
+    Field,
+    Json,
+    PositiveInt,
+    error_wrappers,
+    validator,
+)
 from src.schema_helpers import SpatioTemporalExtent
 from stac_pydantic import Collection, Item, shared
 from stac_pydantic.links import Link
@@ -17,6 +24,10 @@ from fastapi.exceptions import RequestValidationError
 
 if TYPE_CHECKING:
     from src import services
+
+
+class Link(Link, extra="allow"):
+    pass
 
 
 class AccessibleAsset(shared.Asset):

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import src.validators as validators
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     Json,
     PositiveInt,
@@ -26,8 +27,8 @@ if TYPE_CHECKING:
     from src import services
 
 
-class Link(Link, extra="allow"):
-    pass
+class LinkWithExtraFields(Link):
+    model_config = ConfigDict(extra="allow")
 
 
 class AccessibleAsset(shared.Asset):
@@ -60,7 +61,7 @@ class DashboardCollection(Collection):
     is_periodic: Optional[bool] = Field(default=False, alias="dashboard:is_periodic")
     time_density: Optional[str] = Field(default=None, alias="dashboard:time_density")
     item_assets: Optional[Dict]
-    links: Optional[List[Link]]
+    links: Optional[List[LinkWithExtraFields]]
     assets: Optional[Dict]
     extent: SpatioTemporalExtent
 


### PR DESCRIPTION
### Issue

The web-map-links stac extension that we use for arcgis collections to host WMS URLs contains optional fields in the collection link ("wms:layers", "wms:styles"). Currently, when we ingest a collection, these fields are removed.

### What?

- Allows adding extra fields to the collection links.

### Why?

- see issue ☝️ 

### Testing?

- Publish a collection with extra fields, it should show up in the catalog

