### PR TITLE
chore: add gitignore entry for Jetbrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ cdk-dev.out
 stac-browser
 
 container_logs.log
+
+# Jetbrains IDEs
+.idea


### PR DESCRIPTION
### What?

Add `.idea` to `.gitignore`

### Why?

Some people (me) use Jetbrains IDE's and not VS Code

### Testing?

I've not commited up the `.idea` folder because I can't now :smile:
