### PR TITLE
feat: deterministic outputs of service urls

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -100,4 +100,4 @@ runs:
       working-directory: ${{ inputs.dir }}
       run: |
         echo $STAGE
-        cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json
+        cdk deploy --require-approval never --outputs-file ${HOME}/veda-backend-cdk-outputs.json

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -100,4 +100,4 @@ runs:
       working-directory: ${{ inputs.dir }}
       run: |
         echo $STAGE
-        cdk deploy --require-approval never --outputs-file ${HOME}/veda-backend-cdk-outputs.json
+        cdk deploy --require-approval never --outputs-file ${HOME}/cdk-outputs.json

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -104,7 +104,7 @@ class ApiConstruct(Construct):
             "stac-ingestor-api-url",
             export_name=f"{stack_name}-stac-ingestor-api-url",
             value=self.api.url,
-            key="ingestapiurl"
+            key="ingestapiurl",
         )
 
         register_ssm_parameter(

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -98,13 +98,13 @@ class ApiConstruct(Construct):
             custom_host=config.custom_host,
         )
 
-        # CfnOutput(self, "ingest-api", value=self.api.url)
         stack_name = Stack.of(self).stack_name
         CfnOutput(
             self,
             "stac-ingestor-api-url",
             export_name=f"{stack_name}-stac-ingestor-api-url",
             value=self.api.url,
+            key="ingestapiurl"
         )
 
         register_ssm_parameter(

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -122,7 +122,7 @@ class RasterApiLambdaConstruct(Construct):
             "raster-api",
             value=self.raster_api.url,
             export_name=f"{stack_name}-raster-url",
-            key="rasterapiurl"
+            key="rasterapiurl",
         )
         CfnOutput(self, "raster-api-arn", value=veda_raster_function.function_arn)
 

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -122,6 +122,7 @@ class RasterApiLambdaConstruct(Construct):
             "raster-api",
             value=self.raster_api.url,
             export_name=f"{stack_name}-raster-url",
+            key="rasterapiurl"
         )
         CfnOutput(self, "raster-api-arn", value=veda_raster_function.function_arn)
 

--- a/s3_website/infrastructure/construct.py
+++ b/s3_website/infrastructure/construct.py
@@ -50,4 +50,5 @@ class VedaWebsite(Construct):
             self,
             "bucket-website",
             value=f"https://{self.bucket.bucket_website_domain_name}",
+            key="stacbrowserurl"
         )

--- a/s3_website/infrastructure/construct.py
+++ b/s3_website/infrastructure/construct.py
@@ -50,5 +50,5 @@ class VedaWebsite(Construct):
             self,
             "bucket-website",
             value=f"https://{self.bucket.bucket_website_domain_name}",
-            key="stacbrowserurl"
+            key="stacbrowserurl",
         )

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -120,4 +120,5 @@ class StacApiLambdaConstruct(Construct):
             "stac-api",
             value=self.stac_api.url,
             export_name=f"{stack_name}-stac-url",
+            key="stacapiurl"
         )

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -120,5 +120,5 @@ class StacApiLambdaConstruct(Construct):
             "stac-api",
             value=self.stac_api.url,
             export_name=f"{stack_name}-stac-url",
-            key="stacapiurl"
+            key="stacapiurl",
         )


### PR DESCRIPTION
Towards #402 

# What this PR is

This PR ensures that outputs from CDK for the following services: `stac-api`, `ingest-api`, `raster-api` and `stac-browser` are available and deterministically named.

Prior to this change, if you piped the outputs to a file, you get a combination of `export_name` and a hash, which will cause issues when trying to retrieve values from the outputs for later jobs.

To get around this, I've specified the `key` parameter which explicitly tells CDK to save the outputs under a name without any logical ID logic from CDK.

I've also renamed the outputs file for this action to be `veda-backend-cdk-outputs.json` just so it's clear which stack it's for and prevents any clashes from further stacks we deploy.

# How you can test it

You can run a `cdk deploy/diff` locally and notice that the outputs are generated with the deterministic names, you can see the difference when compared to outputs I've not changed yet:

```
{
  "veda-backend-ciaran-dev": {
    "rasterapiurl": "https://333omprhn9.execute-api.us-west-2.amazonaws.com/",
    "rasterapirasterapiarn1578467D": "arn:aws:lambda:us-west-2:853558080719:function:veda-backend-ciaran-dev-rasterapilambda27FDBBDF-x0eDtlf33IGK",
    "ingestapiurl": "https://og1qrf4cu6.execute-api.us-west-2.amazonaws.com/",
    "stacapiurl": "https://9cwrbb8l4i.execute-api.us-west-2.amazonaws.com/",
    "stacbrowserurl": "https://veda-ciaran-dev-stac-browser.s3-website-us-west-2.amazonaws.com",
    "databasepgstacsecretnameBAF265DE": "a-value",
    "networkvpcid3E9D121F": "a-value"
  }
}
```

You can see that the arns are still logical output id's and so is the secret name.
