### PR TITLE
fix: address dependabot alert 4

### DIFF
--- a/ingest_api/runtime/requirements.txt
+++ b/ingest_api/runtime/requirements.txt
@@ -1,7 +1,7 @@
 # Waiting for https://github.com/stac-utils/stac-pydantic/pull/116 and 117
 cryptography>=42.0.5
 ddbcereal==2.1.1
-fastapi<=0.108.0
+fastapi>=0.109.1
 fsspec==2023.3.0
 mangum>=0.15.0
 orjson>=3.6.8

--- a/ingest_api/runtime/tests/conftest.py
+++ b/ingest_api/runtime/tests/conftest.py
@@ -27,7 +27,7 @@ def test_environ():
     os.environ["RASTER_URL"] = "https://test-raster.url"
     os.environ["USERPOOL_ID"] = "fake_id"
     os.environ["STAGE"] = "testing"
-    os.environ["ROOT_PATH"] = "/"
+    os.environ["ROOT_PATH"] = ""
     os.environ["COGNITO_DOMAIN"] = "https://test-cognito.url"
 
 


### PR DESCRIPTION
# What this PR is 

This PR bumps up `fastapi` in `ingest_api` to address: https://github.com/NASA-IMPACT/veda-backend/security/dependabot/4

The tests failed and it appears to be: https://github.com/fastapi/fastapi/discussions/11102 where root path behaviour changed in some uvicorn update

So I set it to `""` rather than `"/"` and this appears to work 🤷 
