### PR TITLE
fix: add auth requirements install for ingest-api tests

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install reqs for ingest api
         run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
 
+      - name: Install veda auth for ingest api
+        run: python -m pip install common/auth
+
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install reqs for ingest api
         run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
 
+      - name: Install veda auth for ingest api
+        run: python -m pip install common/auth
+
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
 


### PR DESCRIPTION
# Description

Adds auth requirements installation before ingest API tests to address the error in the workflow https://github.com/NASA-IMPACT/veda-backend/actions/runs/10268965811

For later: We should reuse tests rather than duplicate them in each workflow