### PR TITLE
fix: output stac bucket name not host

### DIFF
--- a/s3_website/infrastructure/construct.py
+++ b/s3_website/infrastructure/construct.py
@@ -48,7 +48,7 @@ class VedaWebsite(Construct):
 
         CfnOutput(
             self,
-            "bucket-website",
-            value=f"https://{self.bucket.bucket_website_domain_name}",
-            key="stacbrowserurl",
+            "stac-browser-bucket-name",
+            value=self.bucket.bucket_name,
+            key="stacbrowserbucketname",
         )


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-routes/issues/2

### What?

Changing the output of the STAC Browser from hostname to bucket name

### Why?

You can't import a bucket into a stack by hostname alone, could infer it with some regex, but seems safer to just export the name. You can then get the hostname from the imported construct

### Testing?

Run locally and the exported value indeed changed

