### PR TITLE
fix: update domain names to support multiple domain names for prod

### DIFF
--- a/routes/infrastructure/config.py
+++ b/routes/infrastructure/config.py
@@ -48,6 +48,11 @@ class vedaRouteSettings(BaseSettings):
         None, description="Shared Web ACL ID ARN for CloudFront Distribution"
     )
 
+    custom_host: str = Field(
+        None,
+        description="Complete url of custom host including subdomain. Used to infer url of stac-api before app synthesis.",
+    )
+
     class Config:
         """model config"""
 

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -56,6 +56,16 @@ class CloudfrontDistributionConstruct(Construct):
                     ),
                 )
 
+                if stage == "production" and veda_route_settings.domain_hosted_zone_name == "openveda.cloud":
+                    cf_domain_names=[
+                          f"{stage}.{veda_route_settings.domain_hosted_zone_name}",
+                          f"{veda_route_settings.domain_hosted_zone_name}"
+                      ]
+                else:
+                    cf_domain_names=[
+                          f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
+                      ]
+
                 self.distribution = cf.Distribution(
                     self,
                     stack_name,
@@ -73,9 +83,7 @@ class CloudfrontDistributionConstruct(Construct):
                     default_root_object="index.html",
                     enable_logging=True,
                     web_acl_id=veda_route_settings.shared_web_acl_id,
-                    domain_names=[
-                        f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
-                    ]
+                    domain_names=cf_domain_names
                     if veda_route_settings.domain_hosted_zone_name
                     else None,
                 )
@@ -112,9 +120,7 @@ class CloudfrontDistributionConstruct(Construct):
                     certificate=domain_cert,
                     default_root_object="index.html",
                     enable_logging=True,
-                    domain_names=[
-                        f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
-                    ]
+                    domain_names=cf_domain_names
                     if veda_route_settings.domain_hosted_zone_name
                     else None,
                 )

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -56,15 +56,18 @@ class CloudfrontDistributionConstruct(Construct):
                     ),
                 )
 
-                if stage == "production" and veda_route_settings.domain_hosted_zone_name == "openveda.cloud":
-                    self.cf_domain_names=[
-                          f"{stage}.{veda_route_settings.domain_hosted_zone_name}",
-                          f"{veda_route_settings.domain_hosted_zone_name}"
-                      ]
+                if (
+                    stage == "production"
+                    and veda_route_settings.domain_hosted_zone_name == "openveda.cloud"
+                ):
+                    self.cf_domain_names = [
+                        f"{stage}.{veda_route_settings.domain_hosted_zone_name}",
+                        f"{veda_route_settings.domain_hosted_zone_name}",
+                    ]
                 else:
-                    self.cf_domain_names=[
-                          f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
-                      ]
+                    self.cf_domain_names = [
+                        f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
+                    ]
 
                 self.distribution = cf.Distribution(
                     self,

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -56,8 +56,8 @@ class CloudfrontDistributionConstruct(Construct):
                     ),
                 )
                 if (
-                    veda_route_settings.domain_hosted_zone_name == veda_route_settings.custom_host
-
+                    veda_route_settings.domain_hosted_zone_name
+                    == veda_route_settings.custom_host
                 ):
                     self.cf_domain_names = [
                         f"{stage}.{veda_route_settings.domain_hosted_zone_name}",

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -55,10 +55,9 @@ class CloudfrontDistributionConstruct(Construct):
                         description="Origin Access Control for STAC Browser",
                     ),
                 )
-
                 if (
-                    stage == "production"
-                    and veda_route_settings.domain_hosted_zone_name == "openveda.cloud"
+                    veda_route_settings.domain_hosted_zone_name == veda_route_settings.custom_host
+
                 ):
                     self.cf_domain_names = [
                         f"{stage}.{veda_route_settings.domain_hosted_zone_name}",

--- a/routes/infrastructure/construct.py
+++ b/routes/infrastructure/construct.py
@@ -57,12 +57,12 @@ class CloudfrontDistributionConstruct(Construct):
                 )
 
                 if stage == "production" and veda_route_settings.domain_hosted_zone_name == "openveda.cloud":
-                    cf_domain_names=[
+                    self.cf_domain_names=[
                           f"{stage}.{veda_route_settings.domain_hosted_zone_name}",
                           f"{veda_route_settings.domain_hosted_zone_name}"
                       ]
                 else:
-                    cf_domain_names=[
+                    self.cf_domain_names=[
                           f"{stage}.{veda_route_settings.domain_hosted_zone_name}"
                       ]
 
@@ -83,7 +83,7 @@ class CloudfrontDistributionConstruct(Construct):
                     default_root_object="index.html",
                     enable_logging=True,
                     web_acl_id=veda_route_settings.shared_web_acl_id,
-                    domain_names=cf_domain_names
+                    domain_names=self.cf_domain_names
                     if veda_route_settings.domain_hosted_zone_name
                     else None,
                 )
@@ -120,7 +120,7 @@ class CloudfrontDistributionConstruct(Construct):
                     certificate=domain_cert,
                     default_root_object="index.html",
                     enable_logging=True,
-                    domain_names=cf_domain_names
+                    domain_names=self.cf_domain_names
                     if veda_route_settings.domain_hosted_zone_name
                     else None,
                 )


### PR DESCRIPTION
### What?

- Change supports multiple alternate domain names (CNAMES) for cloudfront distribution for production since it also needs an alternate domain name of `openveda.cloud`

### Why?

- So that we don't have to manually configure this and to empower those without MCP access to successfully deploy mcp-prod

### Testing?

- Tested in UAH account on new stack `veda-jt-test`

