### PR TITLE
fix: check none enddate in temporal validator

### DIFF
--- a/ingest_api/runtime/src/schema_helpers.py
+++ b/ingest_api/runtime/src/schema_helpers.py
@@ -41,10 +41,10 @@ class BboxExtent(BaseModel):
 
 class TemporalExtent(BaseModel):
     startdate: datetime
-    enddate: datetime
+    enddate: Union[datetime, None]
 
     @root_validator
     def check_dates(cls, v):
-        if v["startdate"] >= v["enddate"]:
+        if (v["enddate"] is not None) and (v["startdate"] >= v["enddate"]):
             raise ValueError("Invalid extent - startdate must be before enddate")
         return v

--- a/ingest_api/runtime/src/schema_helpers.py
+++ b/ingest_api/runtime/src/schema_helpers.py
@@ -40,7 +40,7 @@ class BboxExtent(BaseModel):
 
 
 class TemporalExtent(BaseModel):
-    startdate: datetime
+    startdate: Union[datetime, None]
     enddate: Union[datetime, None]
 
     @root_validator


### PR DESCRIPTION
Fix temporal validator in cases where a collection has a `null` enddate as per STAC spec: https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object

Tested with the following dataset config:
```json
{
  "collection": "fldas-soil-moisture-anomalies",
  "title": "FLDAS Surface Soil Moisture Anomalies",
  "data_type": "cog",
  "spatial_extent": {
    "xmin": -180,
    "ymin": -60,
    "xmax": 180,
    "ymax": 90
  },
  "temporal_extent": {
    "startdate": "1982-01-01T00:00:00Z",
    "enddate": null
  },
  "license": "not-provided",
  "description": "A 10 km global data product with 40 years of monthly soil moisture anomalies for food and water security monitoring from the Famine Early Warning System Network (FEWS NET) Land Data Assimilation System",
  "is_periodic": false,
  "time_density": "month",
  "sample_files": [
    "s3://veda-data-store-staging/fldas-soil-moisture-anomalies/FLDAS_NOAH01_SoilMoi00_10cm_tavg_C_GL_MA_ANOM198201_19820101.tif"
  ],
  "discovery_items": [
    {
      "discovery": "s3",
      "prefix": "fldas-soil-moisture-anomalies/",
      "bucket": "veda-data-store-staging",
      "filename_regex": "(.*)FLDAS_NOAH01_SoilMoi00_10cm_tavg_C_GL_MA_ANOM(.*).tif$"
    }
  ]
}
```