### PR TITLE
chore: remove moto from setup. leave in requirements_dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ extra_reqs = {
         "pypgstac==0.7.4",
         "psycopg[binary, pool]",
         "fastapi",
-        "moto",
         "openapi-schema-validator",
     ],
 }


### PR DESCRIPTION

### What?
We were seeing `cannot import name 'mock_dynamodb' from 'moto` because moto made a breaking change on the imports in moto version 5. 
We already have `moto[dynamodb, ssm]>=4.0.9,<5.0` in the ingest api `requirements_dev` to address this, but there was an unpinned version in the `setup.py`.  I'm making this change to just have the import with the pinned version in a single location.
