### PR TITLE
test: Fix transaction unit tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,7 +87,7 @@ jobs:
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
 
       - name: Stac-api transactions unit tests
-        run: python -m pytest stac_api/runtime/tests/ -vv -s
+        run: python -m pytest stac_api/runtime/tests/ --asyncio-mode=auto -vv -s
 
       - name: Stop services
         run: docker compose stop

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,8 +83,8 @@ jobs:
       - name: Ingest unit tests
         run: NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest ingest_api/runtime/tests/ -vv -s
 
-      # - name: Stac-api transactions unit tests
-      #   run: python -m pytest stac_api/runtime/tests/ -vv -s
+      - name: Stac-api transactions unit tests
+        run: python -m pytest stac_api/runtime/tests/ -vv -s
 
       - name: Stop services
         run: docker compose stop

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install reqs for ingest api
         run: python -m pip install -r ingest_api/runtime/requirements_dev.txt
 
+      - name: Install reqs for stac api
+        run: python -m pip install stac_api/runtime/
+
       - name: Install veda auth for ingest api
         run: python -m pip install common/auth
 

--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -28,8 +28,11 @@ trap cleanup EXIT
 # Load data for tests
 docker exec veda.db /tmp/scripts/bin/load-data.sh
 
-# Run tests
-python -m pytest .github/workflows/tests/ -vv -s
+# # Run tests
+# python -m pytest .github/workflows/tests/ -vv -s
 
-# Run ingest unit tests
-NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest --cov=ingest_api/runtime/src ingest_api/runtime/tests/ -vv -s
+# # Run ingest unit tests
+# NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest --cov=ingest_api/runtime/src ingest_api/runtime/tests/ -vv -s
+
+# Transactions tests
+python -m pytest stac_api/runtime/tests/ --asyncio-mode=auto -vv -s

--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -28,11 +28,11 @@ trap cleanup EXIT
 # Load data for tests
 docker exec veda.db /tmp/scripts/bin/load-data.sh
 
-# # Run tests
-# python -m pytest .github/workflows/tests/ -vv -s
+# Run tests
+python -m pytest .github/workflows/tests/ -vv -s
 
-# # Run ingest unit tests
-# NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest --cov=ingest_api/runtime/src ingest_api/runtime/tests/ -vv -s
+# Run ingest unit tests
+NO_PYDANTIC_SSM_SETTINGS=1 python -m pytest --cov=ingest_api/runtime/src ingest_api/runtime/tests/ -vv -s
 
 # Transactions tests
 python -m pytest stac_api/runtime/tests/ --asyncio-mode=auto -vv -s

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -236,8 +236,8 @@ def test_environ():
     os.environ["POSTGRES_USER"] = "username"
     os.environ["POSTGRES_PASS"] = "password"
     os.environ["POSTGRES_DBNAME"] = "postgis"
-    os.environ["POSTGRES_HOST_READER"] = "database"
-    os.environ["POSTGRES_HOST_WRITER"] = "database"
+    os.environ["POSTGRES_HOST_READER"] = "0.0.0.0"
+    os.environ["POSTGRES_HOST_WRITER"] = "0.0.0.0"
     os.environ["POSTGRES_PORT"] = "5432"
 
 

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -291,8 +291,10 @@ async def api_client(app):
     app.dependency_overrides[auth.validated_token] = override_validated_token
     base_url = "http://test"
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url=base_url) as c:
-        yield c
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url=base_url
+    ) as client:
+        yield client
 
     app.dependency_overrides.clear()
 

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -11,7 +11,6 @@ import os
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-
 VALID_COLLECTION = {
     "id": "CMIP245-winter-median-pr",
     "type": "Collection",

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -11,6 +11,8 @@ import os
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
+
 VALID_COLLECTION = {
     "id": "CMIP245-winter-median-pr",
     "type": "Collection",
@@ -208,7 +210,7 @@ VALID_ITEM = {
 }
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def test_environ():
     """
     Set up the test environment with mocked AWS and PostgreSQL credentials.
@@ -250,7 +252,7 @@ def override_validated_token():
 
 
 @pytest.fixture
-def app(test_environ):
+async def app():
     """
     Fixture to initialize the FastAPI application.
 
@@ -265,7 +267,9 @@ def app(test_environ):
     """
     from src.app import app
 
-    return app
+    await connect_to_db(app)
+    yield app
+    await close_db_connection(app)
 
 
 @pytest.fixture(scope="function")

--- a/stac_api/runtime/tests/test_transactions.py
+++ b/stac_api/runtime/tests/test_transactions.py
@@ -53,59 +53,59 @@ class TestList:
         self.invalid_stac_collection = invalid_stac_collection
         self.invalid_stac_item = invalid_stac_item
 
-    def test_post_invalid_collection(self):
+    async def test_post_invalid_collection(self):
         """
         Test the API's response to posting an invalid STAC collection.
 
         Asserts that the response status code is 422 and the detail
         is "Validation Error".
         """
-        response = self.api_client.post(
+        response = await self.api_client.post(
             collections_endpoint, json=self.invalid_stac_collection
         )
         assert response.json()["detail"] == "Validation Error"
         assert response.status_code == 422
 
-    def test_post_valid_collection(self):
+    async def test_post_valid_collection(self):
         """
         Test the API's response to posting a valid STAC collection.
 
         Asserts that the response status code is 200.
         """
-        response = self.api_client.post(
+        response = await self.api_client.post(
             collections_endpoint, json=self.valid_stac_collection
         )
         # assert response.json() == {}
         assert response.status_code == 200
 
-    def test_post_invalid_item(self):
+    async def test_post_invalid_item(self):
         """
         Test the API's response to posting an invalid STAC item.
 
         Asserts that the response status code is 422 and the detail
         is "Validation Error".
         """
-        response = self.api_client.post(
+        response = await self.api_client.post(
             items_endpoint.format(self.invalid_stac_item["collection"]),
             json=self.invalid_stac_item,
         )
         assert response.json()["detail"] == "Validation Error"
         assert response.status_code == 422
 
-    def test_post_valid_item(self):
+    async def test_post_valid_item(self):
         """
         Test the API's response to posting a valid STAC item.
 
         Asserts that the response status code is 200.
         """
-        response = self.api_client.post(
+        response = await self.api_client.post(
             items_endpoint.format(self.valid_stac_item["collection"]),
             json=self.valid_stac_item,
         )
         # assert response.json() == {}
         assert response.status_code == 200
 
-    def test_post_invalid_bulk_items(self):
+    async def test_post_invalid_bulk_items(self):
         """
         Test the API's response to posting invalid bulk STAC items.
 
@@ -117,12 +117,12 @@ class TestList:
             "items": {item_id: self.invalid_stac_item},
             "method": "upsert",
         }
-        response = self.api_client.post(
+        response = await self.api_client.post(
             bulk_endpoint.format(collection_id), json=invalid_request
         )
         assert response.status_code == 422
 
-    def test_post_valid_bulk_items(self):
+    async def test_post_valid_bulk_items(self):
         """
         Test the API's response to posting valid bulk STAC items.
 
@@ -131,7 +131,7 @@ class TestList:
         item_id = self.valid_stac_item["id"]
         collection_id = self.valid_stac_item["collection"]
         valid_request = {"items": {item_id: self.valid_stac_item}, "method": "upsert"}
-        response = self.api_client.post(
+        response = await self.api_client.post(
             bulk_endpoint.format(collection_id), json=valid_request
         )
         assert response.status_code == 200


### PR DESCRIPTION
I've added a small change in the `stac_api/runtime/tests/conftest.py`. This gives a similar error on each of the attempts to POST: The error error:
```
>       response = self.api_client.post(
            collections_endpoint, json=self.invalid_stac_collection
        )
E       AttributeError: 'async_generator' object has no attribute 'post'

stac_api/runtime/tests/test_transactions.py:63: AttributeError
```

this got past the starlette error that we were seeing in develop:
```
self = <starlette.datastructures.State object at 0x10bf0b1f0>, key = 'get_connection'

    def __getattr__(self, key: typing.Any) -> typing.Any:
        try:
            return self._state[key]
        except KeyError:
            message = "'{}' object has no attribute '{}'"
>           raise AttributeError(message.format(self.__class__.__name__, key))
E           AttributeError: 'State' object has no attribute 'get_connection'
```
I'm at a loss on how to get past the new post error, though.

stephenkilbourn