### PR TITLE
fix: cast stac url as string in collection exists validator

### DIFF
--- a/ingest_api/runtime/src/validators.py
+++ b/ingest_api/runtime/src/validators.py
@@ -90,7 +90,7 @@ def collection_exists(collection_id: str) -> bool:
     from src.main import settings
 
     url = "/".join(
-        f'{url.strip("/")}' for url in [settings.stac_url, "collections", collection_id]
+        f'{url.strip("/")}' for url in [str(settings.stac_url), "collections", collection_id]
     )
 
     if (response := requests.get(url)).ok:

--- a/ingest_api/runtime/src/validators.py
+++ b/ingest_api/runtime/src/validators.py
@@ -90,7 +90,8 @@ def collection_exists(collection_id: str) -> bool:
     from src.main import settings
 
     url = "/".join(
-        f'{url.strip("/")}' for url in [str(settings.stac_url), "collections", collection_id]
+        f'{url.strip("/")}'
+        for url in [str(settings.stac_url), "collections", collection_id]
     )
 
     if (response := requests.get(url)).ok:


### PR DESCRIPTION
### What
Resolve new `AttributeError: 'AnyHttpUrl' object has no attribute 'strip'"` error from ingest-api collection exists validator

