### PR TITLE
fix: change dynamo db method reference

### DIFF
--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -126,6 +126,7 @@ class Ingestion(BaseModel):
         return v or datetime.now()
 
     def enqueue(self, db: "services.Database"):
+        self.created_at = datetime.now()
         self.status = Status.queued
         return self.save(db)
 

--- a/ingest_api/runtime/src/services.py
+++ b/ingest_api/runtime/src/services.py
@@ -18,7 +18,7 @@ class Database:
         self.table = table
 
     def write(self, ingestion: schemas.Ingestion):
-        self.table.put_item(Item=ingestion.dynamo_db_dict())
+        self.table.put_item(Item=ingestion.dynamodb_dict())
 
     def fetch_one(self, username: str, ingestion_id: str):
         response = self.table.get_item(


### PR DESCRIPTION
Fix the dynamo table write method to use the correct ingestion schema method name:

```
def write(self, ingestion: schemas.Ingestion):
        self.table.put_item(Item=ingestion.dynamodb_dict())
```

