### PR TITLE
fix: update typo to correctly call dynamodb_dict

### DIFF
--- a/ingest_api/runtime/src/services.py
+++ b/ingest_api/runtime/src/services.py
@@ -18,7 +18,7 @@ class Database:
         self.table = table
 
     def write(self, ingestion: schemas.Ingestion):
-        self.table.put_item(Item=ingestion.dynamo_db_dict())
+        self.table.put_item(Item=ingestion.dynamodb_dict())
 
     def fetch_one(self, username: str, ingestion_id: str):
         response = self.table.get_item(


### PR DESCRIPTION
### Issue

```
       "  File \"/var/task/src/main.py\", line 78, in enqueue_ingestion\n    ).enqueue(db)\n      ^^^^^^^^^^^\n",
        "  File \"/var/task/src/schemas.py\", line 130, in enqueue\n    return self.save(db)\n           ^^^^^^^^^^^^^\n",
        "  File \"/var/task/src/schemas.py\", line 138, in save\n    db.write(self)\n",
        "  File \"/var/task/src/services.py\", line 21, in write\n    self.table.put_item(Item=ingestion.dynamo_db_dict())\n                             ^^^^^^^^^^^^^^^^^^^^^^^^\n",
        "  File \"/var/task/pydantic/main.py\", line 891, in __getattr__\n    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')\n"
    ],
    "errorType": "AttributeError",
    "errorMessage": "'Ingestion' object has no attribute 'dynamo_db_dict'",
    "requestId": "82aba2fd-176b-4595-a29b-958e676b0d88",
    "location": "/var/task/mangum/protocols/http.py:run:60"
```

### What?

- Fixes typo in calling method

### Why?

- The function is `dynamodb_dict` not `dynamo_db_dict`

### Testing?

- Relevant testing details

