### PR TITLE
fix(raster-api): update colormaps to include additional custom colormaps

### DIFF
--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -36,7 +36,6 @@ from titiler.pgstac.factory import (
     add_search_register_route,
 )
 from titiler.pgstac.reader import PgSTACReader
-from rio_tiler.types import ColorMapType
 
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
@@ -208,7 +207,7 @@ app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
 ###############################################################################
 cmaps = ColorMapFactory()
 # Set supported colormaps to be the modified cmap list with added colormaps
-cmaps.supported_colormaps=cmap
+cmaps.supported_colormaps = cmap
 app.include_router(cmaps.router, tags=["ColorMaps"])
 
 

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -6,7 +6,7 @@ from aws_lambda_powertools.metrics import MetricUnit
 from src.algorithms import PostProcessParams
 from src.alternate_reader import PgSTACReaderAlt
 from src.config import ApiSettings
-from src.dependencies import ColorMapParams
+from src.dependencies import ColorMapParams, cmap
 from src.extensions import stacViewerExtension
 from src.monitoring import LoggerRouteHandler, logger, metrics, tracer
 from src.version import __version__ as veda_raster_version
@@ -36,6 +36,7 @@ from titiler.pgstac.factory import (
     add_search_register_route,
 )
 from titiler.pgstac.reader import PgSTACReader
+from rio_tiler.types import ColorMapType
 
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
@@ -206,6 +207,8 @@ app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
 # Colormaps endpoints
 ###############################################################################
 cmaps = ColorMapFactory()
+# Set supported colormaps to be the modified cmap list with added colormaps
+cmaps.supported_colormaps=cmap
 app.include_router(cmaps.router, tags=["ColorMaps"])
 
 


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/458

### What?/Why?

- Our colormaps endpoint doesn't include the custom colormaps

### Testing?

- https://jtran.delta-backend.com/api/raster/docs#/ColorMaps/getColorMaps
You will see the endpoint now returns the custom colormaps at the end of the list
```
{
  "colorMaps": [
    "accent",
    .
    .
    .
    "epa-ghgi-ch4",
    "nlcd",
    "soil_texture",
    "surface_temperature",
    "tornado_ef_scale"
  ],
  "links": [
    {
      "href": "https://delta-backend.com/api/raster/colorMaps",
      "rel": "self",
      "type": "application/json",
      "title": "List of available colormaps"
    },
    {
      "href": "https://delta-backend.com/api/raster/colorMaps/{colorMapId}",
      "rel": "data",
      "type": "application/json",
      "templated": true,
      "title": "Retrieve colorMap metadata"
    },
    {
      "href": "https://delta-backend.com/api/raster/colorMaps/{colorMapId}?format=png",
      "rel": "data",
      "type": "image/png",
      "templated": true,
      "title": "Retrieve colorMap as image"
    }
  ]
}
```
