### PR TITLE
fix: set supported_colormaps for colormapfactory

### DIFF
--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -205,11 +205,9 @@ app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
 ###############################################################################
 # Colormaps endpoints
 ###############################################################################
-cmaps = ColorMapFactory()
 # Set supported colormaps to be the modified cmap list with added colormaps
-cmaps.supported_colormaps = cmap
+cmaps = ColorMapFactory(supported_colormaps = cmap)
 app.include_router(cmaps.router, tags=["ColorMaps"])
-
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -206,8 +206,9 @@ app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")
 # Colormaps endpoints
 ###############################################################################
 # Set supported colormaps to be the modified cmap list with added colormaps
-cmaps = ColorMapFactory(supported_colormaps = cmap)
+cmaps = ColorMapFactory(supported_colormaps=cmap)
 app.include_router(cmaps.router, tags=["ColorMaps"])
+
 
 @app.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/458#issuecomment-2707630918

### What?/ Why?

- `colorMaps` endpoint was returning the new colormaps but `colorMaps/colorMapId` wasn't. 

### Testing?

https://jtran.delta-backend.com/api/raster/docs#/ColorMaps/getColorMap

<img width="1682" alt="Screenshot 2025-03-10 at 2 59 35 PM" src="https://github.com/user-attachments/assets/54f9faeb-5322-4431-9070-e436c56dc41b" />

