### PR TITLE
fix: add default for collection assets

### DIFF
--- a/ingest_api/runtime/src/collection_publisher.py
+++ b/ingest_api/runtime/src/collection_publisher.py
@@ -15,7 +15,7 @@ class CollectionPublisher:
         and loads into the PgSTAC collection table
         """
         creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
-        collection = [collection.to_dict()]
+        collection = [collection.to_dict(exclude_none=True)]
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             load_into_pgstac(
                 db=db, ingestions=collection, table=IngestionType.collections

--- a/ingest_api/runtime/src/collection_publisher.py
+++ b/ingest_api/runtime/src/collection_publisher.py
@@ -15,7 +15,7 @@ class CollectionPublisher:
         and loads into the PgSTAC collection table
         """
         creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
-        collection = [collection.to_dict(exclude_none=True)]
+        collection = [collection.to_dict(exclude_unset=True)]
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             load_into_pgstac(
                 db=db, ingestions=collection, table=IngestionType.collections

--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -66,7 +66,7 @@ class DashboardCollection(Collection):
     time_density: Optional[str] = Field(default=None, alias="dashboard:time_density")
     item_assets: Optional[Dict]
     links: Optional[List[LinkWithExtraFields]]
-    assets: Optional[Dict]
+    assets: Optional[Dict] = None
     extent: SpatioTemporalExtent
     model_config = ConfigDict(populate_by_name=True)
     # workaround for https://github.com/pydantic/pydantic/discussions/8211 and https://github.com/pydantic/pydantic/issues/7186 (changes expected on pydantic 3 roadmap)


### PR DESCRIPTION
Add default for assets in ingest api collection validation so it's not a required field in pydantic  v2 as per the migration guide:
https://docs.pydantic.dev/dev/migration/#required-optional-and-nullable-fields