### PR TITLE
fix: pagination in stac api

### DIFF
--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -8,8 +8,8 @@ from aws_lambda_powertools.metrics import MetricUnit
 from src.config import TilesApiSettings, api_settings
 from src.config import extensions as PgStacExtensions
 from src.config import get_request_model as GETModel
-from src.config import post_request_model as POSTModel
 from src.config import items_get_request_model
+from src.config import post_request_model as POSTModel
 from src.extension import TiTilerExtension
 
 from fastapi import APIRouter, FastAPI

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -12,10 +12,9 @@ from src.config import post_request_model as POSTModel
 from src.config import items_get_request_model
 from src.extension import TiTilerExtension
 
-from fastapi import APIRouter, FastAPI, Depends
+from fastapi import APIRouter, FastAPI
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
-from stac_fastapi.types.stac import ItemCollection
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -9,11 +9,13 @@ from src.config import TilesApiSettings, api_settings
 from src.config import extensions as PgStacExtensions
 from src.config import get_request_model as GETModel
 from src.config import post_request_model as POSTModel
+from src.config import items_get_request_model
 from src.extension import TiTilerExtension
 
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Depends
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
+from stac_fastapi.types.stac import ItemCollection
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -74,6 +76,7 @@ api = VedaStacApi(
     client=VedaCrudClient(post_request_model=POSTModel),
     search_get_request_model=GETModel,
     search_post_request_model=POSTModel,
+    items_get_request_model=items_get_request_model,
     response_class=ORJSONResponse,
     middlewares=[Middleware(CompressionMiddleware), Middleware(ValidationMiddleware)],
     router=APIRouter(route_class=LoggerRouteHandler),

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -11,7 +11,12 @@ from pydantic import AnyHttpUrl, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fastapi.responses import ORJSONResponse
-from stac_fastapi.api.models import create_get_request_model, create_post_request_model, ItemCollectionUri, create_request_model
+from stac_fastapi.api.models import (
+    ItemCollectionUri,
+    create_get_request_model,
+    create_post_request_model,
+    create_request_model,
+)
 
 # from stac_fastapi.pgstac.extensions import QueryExtension
 from stac_fastapi.extensions.core import (

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -11,7 +11,7 @@ from pydantic import AnyHttpUrl, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from fastapi.responses import ORJSONResponse
-from stac_fastapi.api.models import create_get_request_model, create_post_request_model
+from stac_fastapi.api.models import create_get_request_model, create_post_request_model, ItemCollectionUri, create_request_model
 
 # from stac_fastapi.pgstac.extensions import QueryExtension
 from stac_fastapi.extensions.core import (
@@ -132,13 +132,21 @@ def TilesApiSettings() -> _TilesApiSettings:
     return _TilesApiSettings()
 
 
+pagination_extension = TokenPaginationExtension()
+
 extensions = [
     FieldsExtension(),
     FilterExtension(),
     QueryExtension(),
     SortExtension(),
-    TokenPaginationExtension(),
+    pagination_extension,
 ]
+
+items_get_request_model = create_request_model(
+    "ItemCollectionURI",
+    base_model=ItemCollectionUri,
+    mixins=[pagination_extension.GET],
+)
 
 if api_settings.enable_transactions:
     extensions.extend(


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/473

### What? / Why?

- Pagination was not working due changes made to [Pagination extension ](https://stac-utils.github.io/stac-fastapi/migrations/v3.0.0/#request-models). Updating to use a request model fixed it.
### Testing?

https://jtran.delta-backend.com/api/stac/collections/snow-projections-diff-245/items?token=next:snow-projections-diff-245:CSCD_SWE_tavg_ssp245_20770401_percChange.cog
