### PR TITLE
fix: add debugging to stac api lambda envs

### DIFF
--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -37,15 +37,15 @@ class StacApiLambdaConstruct(Construct):
         # TODO config
         stack_name = Stack.of(self).stack_name
 
+        print(f"DEBUG - stac_enable_transactions: {veda_stac_settings.stac_enable_transactions}")
+        print(f"DEBUG - keycloak_client_id: {veda_stac_settings.keycloak_client_id}")
+        print(f"DEBUG - openid_configuration_url: {veda_stac_settings.openid_configuration_url}")
+
         lambda_env = {
             "VEDA_STAC_PROJECT_NAME": veda_stac_settings.project_name,
             "VEDA_STAC_PROJECT_DESCRIPTION": veda_stac_settings.project_description,
             "VEDA_STAC_ROOT_PATH": veda_stac_settings.stac_root_path,
             "VEDA_STAC_STAGE": stage,
-            "VEDA_STAC_CLIENT_ID": veda_stac_settings.keycloak_client_id,
-            "VEDA_STAC_OPENID_CONFIGURATION_URL": str(
-                veda_stac_settings.openid_configuration_url
-            ),
             "VEDA_STAC_ENABLE_TRANSACTIONS": str(
                 veda_stac_settings.stac_enable_transactions
             ),
@@ -53,6 +53,15 @@ class StacApiLambdaConstruct(Construct):
             "DB_MAX_CONN_SIZE": "1",
             **{k.upper(): v for k, v in veda_stac_settings.env.items()},
         }
+
+        if veda_stac_settings.keycloak_client_id is not None:
+            lambda_env["VEDA_STAC_CLIENT_ID"] = veda_stac_settings.keycloak_client_id
+        if veda_stac_settings.openid_configuration_url is not None:
+            lambda_env["VEDA_STAC_OPENID_CONFIGURATION_URL"] = str(
+                veda_stac_settings.openid_configuration_url
+            )
+
+        print(f"DEBUG - Final env vars are: {lambda_env}")
 
         lambda_function = aws_lambda.Function(
             self,

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -37,14 +37,6 @@ class StacApiLambdaConstruct(Construct):
         # TODO config
         stack_name = Stack.of(self).stack_name
 
-        print(
-            f"DEBUG - stac_enable_transactions: {veda_stac_settings.stac_enable_transactions}"
-        )
-        print(f"DEBUG - keycloak_client_id: {veda_stac_settings.keycloak_client_id}")
-        print(
-            f"DEBUG - openid_configuration_url: {veda_stac_settings.openid_configuration_url}"
-        )
-
         lambda_env = {
             "VEDA_STAC_PROJECT_NAME": veda_stac_settings.project_name,
             "VEDA_STAC_PROJECT_DESCRIPTION": veda_stac_settings.project_description,
@@ -64,8 +56,6 @@ class StacApiLambdaConstruct(Construct):
             lambda_env["VEDA_STAC_OPENID_CONFIGURATION_URL"] = str(
                 veda_stac_settings.openid_configuration_url
             )
-
-        print(f"DEBUG - Final env vars are: {lambda_env}")
 
         lambda_function = aws_lambda.Function(
             self,

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -37,9 +37,13 @@ class StacApiLambdaConstruct(Construct):
         # TODO config
         stack_name = Stack.of(self).stack_name
 
-        print(f"DEBUG - stac_enable_transactions: {veda_stac_settings.stac_enable_transactions}")
+        print(
+            f"DEBUG - stac_enable_transactions: {veda_stac_settings.stac_enable_transactions}"
+        )
         print(f"DEBUG - keycloak_client_id: {veda_stac_settings.keycloak_client_id}")
-        print(f"DEBUG - openid_configuration_url: {veda_stac_settings.openid_configuration_url}")
+        print(
+            f"DEBUG - openid_configuration_url: {veda_stac_settings.openid_configuration_url}"
+        )
 
         lambda_env = {
             "VEDA_STAC_PROJECT_NAME": veda_stac_settings.project_name,


### PR DESCRIPTION
### Issue

Link to relevant GitHub issue

### What?

- Updated to conditionally add certain env vars based on setting of `stac_enable_transactions`

### Why?

- https://github.com/NASA-IMPACT/veda-deploy/actions/runs/14582901475/job/40903966433 Getting an error trying to deploy MCP test which I believe is due to a null env var value:
```
jsii.errors.JavaScriptError: 
  @jsii/kernel.SerializationError: Passed to parameter props of new aws-cdk-lib.aws_lambda.Function: Unable to deserialize value as aws-cdk-lib.aws_lambda.FunctionProps
  ├── 🛑 Failing value is an object
  │      { '$jsii.struct': [Object] }
  ╰── 🔍 Failure reason(s):
      ╰─ Key 'environment': Unable to deserialize value as map<string> | undefined
          ├── 🛑 Failing value is an object
          │      { '$jsii.map': [Object] }
          ╰── 🔍 Failure reason(s):
              ╰─ Key 'VEDA_STAC_CLIENT_ID': Unable to deserialize value as string
                  ├── 🛑 Failing value is null
                  ╰── 🔍 Failure reason(s):
                      ╰─ A value is required (type is non-optional)
      at Object.process (/tmp/tmpdrhn83pr/lib/program.js:3952:19)
      at Kernel._Kernel_toSandbox (/tmp/tmpdrhn83pr/lib/program.js:884:25)
      at /tmp/tmpdrhn83pr/lib/program.js:900:38
      at Array.map (<anonymous>)
      at Kernel._Kernel_boxUnboxParameters (/tmp/tmpdrhn83pr/lib/program.js:900:23)
      at Kernel._Kernel_toSandboxValues (/tmp/tmpdrhn83pr/lib/program.js:888:101)
      at Kernel._Kernel_create (/tmp/tmpdrhn83pr/lib/program.js:548:115)
      at Kernel.create (/tmp/tmpdrhn83pr/lib/program.js:218:93)
      at KernelHost.processRequest (/tmp/tmpdrhn83pr/lib/program.js:15471:36)
      at KernelHost.run (/tmp/tmpdrhn83pr/lib/program.js:15431:22)
```

### Testing?

- Deployed changes to mcp test https://github.com/NASA-IMPACT/veda-deploy/actions/runs/14582901475
- Pagination working https://test.openveda.cloud/api/stac/collections/snow-projections-diff-245/items?token=next:snow-projections-diff-245:CSCD_SWE_tavg_ssp245_20770401_percChange
