### PR TITLE
fix: remove allow public subnets from lambdas

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,6 @@ ingest_api = ingest_api_construct(
     config=ingestor_config,
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
-    db_vpc_subnets=database.vpc_subnets,
 )
 
 ingestor = ingestor_construct(
@@ -128,7 +127,6 @@ ingestor = ingestor_construct(
     table=ingest_api.table,
     db_secret=database.pgstac.secret,
     db_vpc=vpc.vpc,
-    db_vpc_subnets=database.vpc_subnets,
 )
 
 git_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()

--- a/ingest_api/infrastructure/construct.py
+++ b/ingest_api/infrastructure/construct.py
@@ -24,7 +24,6 @@ class ApiConstruct(Construct):
         config: IngestorConfig,
         db_secret: secretsmanager.ISecret,
         db_vpc: ec2.IVpc,
-        db_vpc_subnets=ec2.SubnetSelection,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -226,7 +225,6 @@ class IngestorConstruct(Construct):
         table: dynamodb.ITable,
         db_secret: secretsmanager.ISecret,
         db_vpc: ec2.IVpc,
-        db_vpc_subnets=ec2.SubnetSelection,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -255,7 +253,6 @@ class IngestorConstruct(Construct):
             db_secret=db_secret,
             db_vpc=db_vpc,
             db_security_group=db_security_group,
-            db_vpc_subnets=db_vpc_subnets,
             pgstac_version=config.db_pgstac_version,
         )
 
@@ -267,7 +264,6 @@ class IngestorConstruct(Construct):
         db_secret: secretsmanager.ISecret,
         db_vpc: ec2.IVpc,
         db_security_group: ec2.ISecurityGroup,
-        db_vpc_subnets: ec2.SubnetSelection,
         pgstac_version: str,
         code_dir: str = "./",
     ) -> aws_lambda.Function:
@@ -285,8 +281,6 @@ class IngestorConstruct(Construct):
             timeout=Duration.seconds(180),
             environment={"DB_SECRET_ARN": db_secret.secret_arn, **env},
             vpc=db_vpc,
-            vpc_subnets=db_vpc_subnets,
-            allow_public_subnet=True,
             memory_size=2048,
         )
 

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -47,7 +47,6 @@ class RasterApiLambdaConstruct(Construct):
                 platform="linux/amd64",
             ),
             vpc=vpc,
-            allow_public_subnet=True,
             handler="handler.handler",
             memory_size=veda_raster_settings.memory,
             timeout=Duration.seconds(veda_raster_settings.timeout),

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -69,7 +69,6 @@ class StacApiLambdaConstruct(Construct):
                 file="stac_api/runtime/Dockerfile",
             ),
             vpc=vpc,
-            allow_public_subnet=True,
             memory_size=veda_stac_settings.memory,
             timeout=Duration.seconds(veda_stac_settings.timeout),
             environment=lambda_env,


### PR DESCRIPTION
- remove `allow_public_subnet` from stac and raster api since they use private subnets
- remove unused `db_vpc_subnets` paramater in ingest api
- remove `allow_public_subnet` from `IngestorConstruct` lambda since it should be placed in private subnet and needs internet access for keycloak auth

## Testing

- This branch was deployed to test.openveda.cloud and [ida-ndwi-difference-test-ingest-api-keycloak](https://dev.openveda.cloud/stac/collections/ida-ndwi-difference-test-ingest-api-keycloak) was ingested using the ingest API directly