### PR TITLE
fix(dependencies): titiler and rio-tiler upgrade

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: false
     type: string
     default: "."
+  skip_tests:
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -54,33 +58,42 @@ runs:
         python -m pip install -e .[dev,deploy,test]
         python -m pip install boto3
 
+     # === Only run these steps if skip_tests is false ===
+
     - name: Launch services
+      if: ${{ inputs.skip_tests == false }}
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: docker compose up --build -d
 
     - name: Ingest Stac Items/Collection
+      if: ${{ inputs.skip_tests == false }}
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |
         ./scripts/load-data-container.sh
 
     - name: Sleep for 10 seconds
-      run: sleep 10s
+      if: ${{ inputs.skip_tests == false }}
       shell: bash
       working-directory: ${{ inputs.dir }}
+      run: sleep 10s
 
     - name: Integrations tests
+      if: ${{ inputs.skip_tests == false }}
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: python -m pytest .github/workflows/tests/ -vv -s
 
     - name: Stop services
+      if: ${{ inputs.skip_tests == false }}
       shell: bash
       working-directory: ${{ inputs.dir }}
       run: |
         docker compose down --rmi all --volumes
         sudo rm -rf .pgdata
+
+    # ===================================================
 
     - name: Get relevant environment configuration from aws secrets
       shell: bash

--- a/.github/workflows/tests/conftest.py
+++ b/.github/workflows/tests/conftest.py
@@ -18,6 +18,7 @@ SEARCH_ROUTE = "search"
 RASTER_SEARCHES_ENDPOINT = "http://0.0.0.0:8082/searches"
 RASTER_HEALTH_ENDPOINT = "http://0.0.0.0:8082/healthz"
 TILEMATRIX = {"z": 15, "x": 8589, "y": 12849}
+TMS_ID = "WebMercatorQuad"
 
 SEARCHES = [
     {
@@ -226,6 +227,17 @@ def seeded_tilematrix():
         dict: A [z, x, y] set of dimensions
     """
     return TILEMATRIX
+
+
+@pytest.fixture
+def seeded_tms_id():
+    """
+    Fixture providing a matrix of seeded data for integration testing.
+
+    Returns:
+        dict: A [z, x, y] set of dimensions
+    """
+    return TMS_ID
 
 
 @pytest.fixture

--- a/.github/workflows/tests/conftest.py
+++ b/.github/workflows/tests/conftest.py
@@ -235,7 +235,7 @@ def seeded_tms_id():
     Fixture providing a matrix of seeded data for integration testing.
 
     Returns:
-        dict: A [z, x, y] set of dimensions
+        string: A valid TileMatrixSet ID
     """
     return TMS_ID
 

--- a/.github/workflows/tests/test_raster.py
+++ b/.github/workflows/tests/test_raster.py
@@ -21,6 +21,7 @@ class TestList:
         raster_health_endpoint,
         seeded_tilematrix,
         searches,
+        seeded_tms_id,
     ):
         """
         Set up the test environment with the required fixtures.
@@ -31,6 +32,7 @@ class TestList:
         self.raster_health_endpoint = raster_health_endpoint
         self.seeded_tilematrix = seeded_tilematrix
         self.searches = searches
+        self.seeded_tms_id = seeded_tms_id
 
     def test_raster_api_health(self):
         """test api."""
@@ -53,9 +55,8 @@ class TestList:
 
         searchid = resp.json()["id"]
         assert resp.status_code == 200
-
         resp = httpx.get(
-            f"{self.raster_searches_endpoint}/{searchid}/-85.6358,36.1624/assets"
+            f"{self.raster_searches_endpoint}/{searchid}/point/-85.6358,36.1624/assets"
         )
         assert resp.status_code == 200
         assert len(resp.json()) == 1
@@ -63,7 +64,7 @@ class TestList:
         assert resp.json()[0]["id"] == self.seeded_id
 
         resp = httpx.get(
-            f"{self.raster_searches_endpoint}/{searchid}/tiles/15/8589/12849/assets"
+            f"{self.raster_searches_endpoint}/{searchid}/tiles/{self.seeded_tms_id}/15/8589/12849/assets"
         )
 
         assert resp.status_code == 200
@@ -72,7 +73,7 @@ class TestList:
         assert resp.json()[0]["id"] == self.seeded_id
 
         resp = httpx.get(
-            f"{self.raster_searches_endpoint}/{searchid}/tiles/{self.seeded_tilematrix['z']}/{self.seeded_tilematrix['x']}/{self.seeded_tilematrix['y']}",
+            f"{self.raster_searches_endpoint}/{searchid}/tiles/{self.seeded_tms_id}/{self.seeded_tilematrix['z']}/{self.seeded_tilematrix['x']}/{self.seeded_tilematrix['y']}",
             params={"assets": "cog"},
             headers={"Accept-Encoding": "br, gzip"},
             timeout=10.0,
@@ -82,7 +83,7 @@ class TestList:
         assert "content-encoding" not in resp.headers
 
         resp = httpx.get(
-            f"{self.raster_searches_endpoint}/{searchid}/tiles/{self.seeded_tilematrix['z']}/{self.seeded_tilematrix['x']}/{self.seeded_tilematrix['y']}/assets"
+            f"{self.raster_searches_endpoint}/{searchid}/tiles/{self.seeded_tms_id}/{self.seeded_tilematrix['z']}/{self.seeded_tilematrix['x']}/{self.seeded_tilematrix['y']}/assets"
         )
         assert resp.status_code == 200
 

--- a/config.py
+++ b/config.py
@@ -84,7 +84,7 @@ class vedaAppSettings(BaseSettings):
         description="Boolean if Cloudfront Distribution should be deployed",
     )
 
-    veda_custom_host: str = Field(
+    veda_custom_host: Optional[str] = Field(
         None,
         description="Complete url of custom host including subdomain. Used to infer url of stac-api before app synthesis.",
     )

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -76,7 +76,7 @@ class vedaRasterSettings(BaseSettings):
         description="Optional root path for all api endpoints",
     )
 
-    custom_host: str = Field(
+    custom_host: Optional[str] = Field(
         None,
         description="Complete url of custom host including subdomain. When provided, override host in api integration",
     )

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -11,7 +11,7 @@ inst_reqs = [
     "rio-tiler>=7.0,<8.0",
     "titiler.pgstac==1.5.0",
     # use highest available titiler based on rio-tiler and titiler-pgstac pins
-    "titiler.core",
+    "titiler.core<0.20",
     "titiler.mosaic",
     "titiler.extensions[cogeo]",
     "starlette-cramjam>=0.3,<0.4",

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -7,12 +7,15 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
-    "rio-tiler==6.5.0",
-    "titiler.pgstac==1.3.0",
-    "titiler.core>=0.18.5,<0.19",
-    "titiler.mosaic>=0.18.5,<0.19",
-    "titiler.extensions[cogeo]>=0.18.5,<0.19",
+    # highest-tested versions of raster_api dependencies
+    "rio-tiler>=7.0,<8.0",
+    "titiler.pgstac==1.5.0",
+    # use highest available titiler based on rio-tiler and titiler-pgstac pins
+    "titiler.core",
+    "titiler.mosaic",
+    "titiler.extensions[cogeo]",
     "starlette-cramjam>=0.3,<0.4",
+    # based on AWS observability requirements
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
     "python-multipart==0.0.7",
@@ -30,7 +33,7 @@ extra_reqs = {
 setup(
     name="veda.raster_api",
     description="",
-    python_requires=">=3.8",
+    python_requires=">=3.12",
     packages=find_namespace_packages(exclude=["tests*"]),
     package_data={"src": ["templates/*.html", "cmap_data/*.npy"]},
     include_package_data=True,

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -23,7 +23,6 @@ from titiler.core.factory import (
     TMSFactory,
 )
 from titiler.core.middleware import CacheControlMiddleware
-from titiler.core.resources.enums import OptionalHeader
 from titiler.core.resources.responses import JSONResponse
 from titiler.extensions import cogValidateExtension, cogViewerExtension
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
@@ -44,10 +43,11 @@ logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 settings = ApiSettings()
 
 
-if settings.debug:
-    optional_headers = [OptionalHeader.server_timing, OptionalHeader.x_assets]
-else:
-    optional_headers = []
+#  TODO - it's unclear how to use these in newer titiler versions
+# if settings.debug:
+#     optional_headers = [OptionalHeader.server_timing, OptionalHeader.x_assets]
+# else:
+#     optional_headers = []
 
 
 @asynccontextmanager
@@ -80,7 +80,6 @@ add_exception_handlers(app, MOSAIC_STATUS_CODES)
 searches = MosaicTilerFactory(
     router_prefix="/searches/{search_id}",
     path_dependency=SearchIdParams,
-    optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     process_dependency=PostProcessParams,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -128,7 +127,6 @@ if settings.enable_mosaic_search:
 ###############################################################################
 collection = MosaicTilerFactory(
     path_dependency=CollectionIdParams,
-    optional_headers=optional_headers,
     router_prefix="/collections/{collection_id}",
     add_statistics=True,
     add_viewer=True,
@@ -148,7 +146,6 @@ app.include_router(
 stac = MultiBaseTilerFactory(
     reader=PgSTACReader,
     path_dependency=ItemIdParams,
-    optional_headers=optional_headers,
     router_prefix="/collections/{collection_id}/items/{item_id}",
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -169,7 +166,6 @@ app.include_router(
 stac_alt = MultiBaseTilerFactory(
     reader=PgSTACReaderAlt,
     path_dependency=ItemIdParams,
-    optional_headers=optional_headers,
     router_prefix="/alt/collections/{collection_id}/items/{item_id}",
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
@@ -190,7 +186,6 @@ app.include_router(
 ###############################################################################
 cog = TilerFactory(
     router_prefix="/cog",
-    optional_headers=optional_headers,
     environment_dependency=settings.get_gdal_config,
     router=APIRouter(route_class=LoggerRouteHandler),
     extensions=[

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -23,6 +23,7 @@ from titiler.core.factory import (
     TMSFactory,
 )
 from titiler.core.middleware import CacheControlMiddleware
+from titiler.core.resources.enums import OptionalHeader
 from titiler.core.resources.responses import JSONResponse
 from titiler.extensions import cogValidateExtension, cogViewerExtension
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
@@ -43,11 +44,10 @@ logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 settings = ApiSettings()
 
 
-#  TODO - it's unclear how to use these in newer titiler versions
-# if settings.debug:
-#     optional_headers = [OptionalHeader.server_timing, OptionalHeader.x_assets]
-# else:
-#     optional_headers = []
+if settings.debug:
+    optional_headers = [OptionalHeader.server_timing, OptionalHeader.x_assets]
+else:
+    optional_headers = []
 
 
 @asynccontextmanager
@@ -93,6 +93,7 @@ searches = MosaicTilerFactory(
     extensions=[
         searchInfoExtension(),
     ],
+    optional_headers=optional_headers,
 )
 app.include_router(
     searches.router, prefix="/searches/{search_id}", tags=["STAC Search"]
@@ -134,6 +135,7 @@ collection = MosaicTilerFactory(
     extensions=[
         searchInfoExtension(),
     ],
+    optional_headers=optional_headers,
 )
 app.include_router(
     collection.router, tags=["STAC Collection"], prefix="/collections/{collection_id}"
@@ -153,6 +155,7 @@ stac = MultiBaseTilerFactory(
         stacViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
+    # optional_headers=optional_headers,
 )
 app.include_router(
     stac.router,
@@ -173,6 +176,7 @@ stac_alt = MultiBaseTilerFactory(
         stacViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
+    # optional_headers=optional_headers,
 )
 app.include_router(
     stac_alt.router,
@@ -193,6 +197,7 @@ cog = TilerFactory(
         cogViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
+    # optional_headers=optional_headers,
 )
 
 app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")

--- a/raster_api/runtime/src/app.py
+++ b/raster_api/runtime/src/app.py
@@ -155,7 +155,6 @@ stac = MultiBaseTilerFactory(
         stacViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
-    # optional_headers=optional_headers,
 )
 app.include_router(
     stac.router,
@@ -176,7 +175,6 @@ stac_alt = MultiBaseTilerFactory(
         stacViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
-    # optional_headers=optional_headers,
 )
 app.include_router(
     stac_alt.router,
@@ -197,7 +195,6 @@ cog = TilerFactory(
         cogViewerExtension(),
     ],
     colormap_dependency=ColorMapParams,
-    # optional_headers=optional_headers,
 )
 
 app.include_router(cog.router, tags=["Cloud Optimized GeoTIFF"], prefix="/cog")

--- a/raster_api/runtime/src/extensions.py
+++ b/raster_api/runtime/src/extensions.py
@@ -8,7 +8,7 @@ from fastapi import Depends
 from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
-from titiler.core.factory import BaseTilerFactory, FactoryExtension
+from titiler.core.factory import BaseFactory, FactoryExtension
 
 DEFAULT_TEMPLATES = Jinja2Templates(
     env=jinja2.Environment(
@@ -23,7 +23,7 @@ class stacViewerExtension(FactoryExtension):
 
     templates: Jinja2Templates = DEFAULT_TEMPLATES
 
-    def register(self, factory: BaseTilerFactory):
+    def register(self, factory: BaseFactory):
         """Register endpoint to the tiler factory."""
 
         @factory.router.get("/viewer", response_class=HTMLResponse)

--- a/stac_api/infrastructure/config.py
+++ b/stac_api/infrastructure/config.py
@@ -30,7 +30,7 @@ class vedaSTACSettings(BaseSettings):
         description="Optional path prefix to add to all raster endpoints",
     )
 
-    custom_host: str = Field(
+    custom_host: Optional[str] = Field(
         None,
         description="Complete url of custom host including subdomain. When provided, override host in api integration",
     )

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -42,8 +42,8 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_PROJECT_DESCRIPTION": veda_stac_settings.project_description,
             "VEDA_STAC_ROOT_PATH": veda_stac_settings.stac_root_path,
             "VEDA_STAC_STAGE": stage,
-            "VEDA_STAC_CLIENT_ID": veda_stac_settings.keycloak_client_id
-            if veda_stac_settings.keycloak_client_id
+            "VEDA_STAC_CLIENT_ID": veda_stac_settings.keycloak_stac_api_client_id
+            if veda_stac_settings.keycloak_stac_api_client_id
             else "",
             "VEDA_STAC_OPENID_CONFIGURATION_URL": str(
                 veda_stac_settings.openid_configuration_url

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -89,10 +89,10 @@ class StacApiLambdaConstruct(Construct):
         )
 
         if veda_stac_settings.custom_host:
-            titler_endpoint = f"https://{veda_stac_settings.custom_host}{veda_stac_settings.raster_root_path}/"
+            titiler_endpoint = f"https://{veda_stac_settings.custom_host}{veda_stac_settings.raster_root_path}/"
         else:
-            titler_endpoint = raster_api.raster_api.url
-        lambda_function.add_environment("TITILER_ENDPOINT", titler_endpoint)
+            titiler_endpoint = raster_api.raster_api.url
+        lambda_function.add_environment("TITILER_ENDPOINT", titiler_endpoint)
 
         lambda_function.add_environment(
             "VEDA_STAC_PGSTAC_SECRET_ARN", database.pgstac.secret.secret_full_arn

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -42,6 +42,12 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_PROJECT_DESCRIPTION": veda_stac_settings.project_description,
             "VEDA_STAC_ROOT_PATH": veda_stac_settings.stac_root_path,
             "VEDA_STAC_STAGE": stage,
+            "VEDA_STAC_CLIENT_ID": veda_stac_settings.keycloak_client_id
+            if veda_stac_settings.keycloak_client_id
+            else "",
+            "VEDA_STAC_OPENID_CONFIGURATION_URL": str(
+                veda_stac_settings.openid_configuration_url
+            ),
             "VEDA_STAC_ENABLE_TRANSACTIONS": str(
                 veda_stac_settings.stac_enable_transactions
             ),


### PR DESCRIPTION
### Issue

#482 

### What?

- Updates raster API runtime to 3.12
- Updates titiler and titiler-pgstac
- Updates tests to use new endpoints for breaking changes to point queries and TMS inputs
- Flag to disable tests in CI (In veda-deploy, we perform integration tests against deployed services as a separate step after deployment. Disabling the pre-deploy tests makes those deployments faster. Default CI behaviour is unchanged.)
~- [ ] TODO some endpoints no longer have debug headers, I would like to re-enable these before merging, but this is fairly low priority~ see comments

### Testing?

- Pending some fixes to our SIT environment, this has been deployed to https://ig3cl55i3b.execute-api.us-west-2.amazonaws.com/docs
- Integration+unit tests pass
- Local manual tests pass/seem fine
- In particular, I reproduced the issue documented in https://github.com/US-GHG-Center/ghgc-architecture/issues/220 to make sure that we don't see regression in overview quality/accuracy

