### PR TITLE
fix: make item assets optional

### DIFF
--- a/ingest_api/runtime/src/schemas.py
+++ b/ingest_api/runtime/src/schemas.py
@@ -64,8 +64,8 @@ class AccessibleItem(Item):
 class DashboardCollection(Collection):
     is_periodic: Optional[bool] = Field(default=False, alias="dashboard:is_periodic")
     time_density: Optional[str] = Field(default=None, alias="dashboard:time_density")
-    item_assets: Optional[Dict]
-    links: Optional[List[LinkWithExtraFields]]
+    item_assets: Optional[Dict] = None
+    links: Optional[List[LinkWithExtraFields]] = None
     assets: Optional[Dict] = None
     extent: SpatioTemporalExtent
     model_config = ConfigDict(populate_by_name=True)


### PR DESCRIPTION
## Description

For a field to be [optional in pydantic v2 ](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields)it must be set to None or else it will still be required. 

This PR sets `item_assets` and `links` as optional. 

## Testing
- manually deployed and tested in dev.openveda.cloud/api/ingest