### PR TITLE
feat: update stac fast api

### DIFF
--- a/database/runtime/handler.py
+++ b/database/runtime/handler.py
@@ -128,22 +128,6 @@ def create_permissions(cursor, db_name: str, username: str) -> None:
         )
     )
 
-
-def enable_context(cursor) -> None:
-    """Enable context extension for actual and estimated matches in item search and associated optimizations."""
-    cursor.execute(
-        sql.SQL(
-            "INSERT INTO pgstac.pgstac_settings (name, value) "
-            "   VALUES "
-            "       ('context', 'auto'),"
-            "       ('context_estimated_count', '100000'),"
-            "       ('context_estimated_cost', '100000'),"
-            "       ('context_stats_ttl', '1 day')"
-            "   ON CONFLICT ON CONSTRAINT pgstac_settings_pkey DO UPDATE SET value = excluded.value;"
-        )
-    )
-
-
 def register_extensions(cursor) -> None:
     """Add PostGIS extension."""
     cursor.execute(sql.SQL("CREATE EXTENSION IF NOT EXISTS postgis;"))
@@ -452,15 +436,6 @@ def handler(event, context):
                     cursor=cur,
                     db_name=user_params["dbname"],
                     username=user_params["username"],
-                )
-
-        with psycopg.connect(stac_db_conninfo, autocommit=True) as conn:
-            with conn.cursor() as cur:
-                print(
-                    "Enabling and configuring item search context in pgstac_settings..."
-                )
-                enable_context(
-                    cursor=cur,
                 )
 
         print("Adding mosaic index...")

--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -9,10 +9,10 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
-    "stac-fastapi.api~=3.0",
-    "stac-fastapi.types~=3.0",
-    "stac-fastapi.extensions~=3.0",
-    "stac-fastapi.pgstac~=3.0",
+    "stac-fastapi.api~=5.0",
+    "stac-fastapi.types~=5.0",
+    "stac-fastapi.extensions~=5.0",
+    "stac-fastapi.pgstac~=5.0",
     "jinja2>=2.11.2,<4.0.0",
     "starlette-cramjam>=0.3.2,<0.4",
     "importlib_resources>=1.1.0;python_version<='3.11'",  # https://github.com/cogeotiff/rio-tiler/pull/379


### PR DESCRIPTION
## Description

- update stac-fastapi to `~=5.0`
- remove context extension from pgstac since it's [deprecated](https://github.com/stac-utils/pgstac/blob/main/CHANGELOG.md#v090). 