### PR TITLE
fix(stac): resolve duplicated root path bug

### DIFF
--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -12,7 +12,7 @@ inst_reqs = [
     "stac-fastapi.api~=5.0",
     "stac-fastapi.types~=5.0",
     "stac-fastapi.extensions~=5.0",
-    "stac-fastapi.pgstac~=5.0",
+    "stac-fastapi.pgstac>=5.0.3,<6.0",
     "jinja2>=2.11.2,<4.0.0",
     "starlette-cramjam>=0.3.2,<0.4",
     "importlib_resources>=1.1.0;python_version<='3.11'",  # https://github.com/cogeotiff/rio-tiler/pull/379


### PR DESCRIPTION
### Issue

https://github.com/stac-utils/stac-fastapi-pgstac/issues/262
https://github.com/NASA-IMPACT/veda-architecture/issues/632

### What?

- Upgrade stac-fastapi.pgstac to root_path fix version to resolve duplicated root path in self and next links.

### Testing?

- Deployed to test instance and confirmed that dynamic urls do not contain duplicated paths.

