### PR TITLE
fix: use replace deprecated custom json serialization with default pydantic v2 model_config

### DIFF
--- a/stac_api/runtime/src/render.py
+++ b/stac_api/runtime/src/render.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 import orjson
 from pydantic import BaseModel, ConfigDict
 
+
 def get_param_str(params: Dict[str, Any]) -> str:
     """Get parameter string from a dictionary of parameters."""
     for k, v in params.items():

--- a/stac_api/runtime/src/render.py
+++ b/stac_api/runtime/src/render.py
@@ -48,7 +48,6 @@ class RenderConfig(BaseModel):
         params = self.render_params.copy()
         return f"{get_param_str(params)}"
 
-    model_config = ConfigDict(json_loads=orjson.loads)
 
 
 def get_render_config(render_params) -> RenderConfig:

--- a/stac_api/runtime/src/render.py
+++ b/stac_api/runtime/src/render.py
@@ -3,8 +3,7 @@ import json
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlencode
 
-import orjson
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
 
 def get_param_str(params: Dict[str, Any]) -> str:
@@ -47,7 +46,6 @@ class RenderConfig(BaseModel):
         """Get the render parameters as a query string."""
         params = self.render_params.copy()
         return f"{get_param_str(params)}"
-
 
 
 def get_render_config(render_params) -> RenderConfig:

--- a/stac_api/runtime/src/render.py
+++ b/stac_api/runtime/src/render.py
@@ -6,12 +6,6 @@ from urllib.parse import urlencode
 import orjson
 from pydantic import BaseModel, ConfigDict
 
-
-def orjson_dumps(v: Dict[str, Any], *args: Any, default: Any) -> str:
-    """orjson.dumps returns bytes, to match standard json.dumps we need to decode."""
-    return orjson.dumps(v, default=default).decode()
-
-
 def get_param_str(params: Dict[str, Any]) -> str:
     """Get parameter string from a dictionary of parameters."""
     for k, v in params.items():
@@ -53,7 +47,7 @@ class RenderConfig(BaseModel):
         params = self.render_params.copy()
         return f"{get_param_str(params)}"
 
-    model_config = ConfigDict(json_loads=orjson.loads, json_dumps=orjson_dumps)
+    model_config = ConfigDict(json_loads=orjson.loads)
 
 
 def get_render_config(render_params) -> RenderConfig:


### PR DESCRIPTION
## Issue
#474 

## What?
removes the json_dumps parameter from the ConfigDict in model_config

## Why?
it is no longer supported by Pydantic V2

## Testing?
Relevant testing details
