### PR TITLE
fix: include tileMatrixSetId in STAC Item map links

### DIFF
--- a/stac_api/runtime/src/links.py
+++ b/stac_api/runtime/src/links.py
@@ -54,7 +54,8 @@ class LinkInjector:
     def _get_item_map_link(self, item_id: str, collection_id: str) -> Dict[str, Any]:
         qs = self.render_config.get_full_render_qs()
         href = urljoin(
-            self.tiler_href, f"collections/{collection_id}/items/{item_id}/map?{qs}"
+            self.tiler_href,
+            f"collections/{collection_id}/items/{item_id}/WebMercatorQuad/map?{qs}",
         )
 
         return {


### PR DESCRIPTION
### Issue

#494 

### What?

Update dynamically rendered titiler map links to include required tile matrix set id.


### Why?

to accomodate changes in[ titiler v0.19.0](https://github.com/developmentseed/titiler/blob/main/CHANGES.md#0190-2024-11-07) 

### Testing?

- Relevant testing details

