### PR TITLE
docs(readme): Fix broken link to raster_api config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The constructs and applications in this project are configured using pydantic. T
 | Database | `VEDA_DB` | [database/infrastructure/config.py](database/infrastructure/config.py) |
 | Domain | `VEDA_DOMAIN` | [domain/infrastructure/config.py](domain/infrastructure/config.py) |
 | Network | `N/A` | [network/infrastructure/config.py](network/infrastructure/config.py) |
-| Raster API (TiTiler) | `VEDA_RASTER` | [raster_api/infrastructure/config.py](raster_-_api/infrastructure/config.py) |
+| Raster API (TiTiler) | `VEDA_RASTER` | [raster_api/infrastructure/config.py](raster_api/infrastructure/config.py) |
 | STAC API | `VEDA` | [stac_api/infrastructure/config.py](stac_api/infrastructure/config.py) |
 | Routes | `VEDA` | [routes/infrastructure/config.py](routes/infrastructure/config.py) |
 | S3 Website | `VEDA` | [s3_website/infrastructure/config.py](s3_website/infrastructure/config.py) |


### PR DESCRIPTION
### Issue

N/A (This is a minor documentation fix that does not have an associated issue.)

### What?

- Corrected a broken hyperlink in the README.md file. The link was intended to point to the raster_api infrastructure configuration but contained a typo.
### Why?

- The existing link was malformed (`raster_-_api` instead of `raster_api`), which caused it to lead to a 404 error page. This fix ensures the documentation is accurate and that the link successfully navigates to the correct file.

### Testing?

- No automated tests are necessary for this change.

- I have manually verified the corrected link by clicking on it in the updated README.md file and confirming that it now opens the target configuration file as expected.

