### PR TITLE
fix: update parse_obj to model_validate

### DIFF
--- a/ingest_api/runtime/tests/conftest.py
+++ b/ingest_api/runtime/tests/conftest.py
@@ -162,6 +162,6 @@ def example_ingestion(example_stac_item):
         id=example_stac_item["id"],
         created_by="test-user",
         status=schemas.Status.queued,
-        item=Item.parse_obj(example_stac_item),
+        item=Item.model_validate(example_stac_item),
         created_at=datetime.now(),
     )

--- a/scripts/run-local-tests.sh
+++ b/scripts/run-local-tests.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# =================================================================
+#  Ensure all Python dependencies are installed
+# =================================================================
+echo "--- Installing all development dependencies ---"
+pip install -r ingest_api/runtime/requirements_dev.txt
+echo "--- Dependency installation complete ---"
+# =================================================================
+
 # Lint
 pre-commit run --all-files
 


### PR DESCRIPTION
### Issue

This resolves the deprecation warning in #510 
```
PydanticDeprecatedSince20: The `parse_obj` method is deprecated; use `model_validate` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```

### What?

Swapped the  The `parse_obj` method with `model_validate` instead.


