### PR TITLE
feat: add GRIB2 support to Raster API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
       - GDAL_HTTP_VERSION=2
       - VSI_CACHE=TRUE
       - VSI_CACHE_SIZE=536870912
+      - CPL_VSIL_CURL_ALLOWED_EXTENSIONS=.tif,.TIF,.tiff,.grib2,.GRIB2
       # TiTiler Config
       - MOSAIC_CONCURRENCY=1
       # AWS S3 endpoint config

--- a/raster_api/infrastructure/config.py
+++ b/raster_api/infrastructure/config.py
@@ -15,7 +15,7 @@ class vedaRasterSettings(BaseSettings):
     # For more information on GDAL env see: https://gdal.org/user/configoptions.html
     # or https://developmentseed.org/titiler/advanced/performance_tuning/
     env: Dict = {
-        "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif,.TIF,.tiff",
+        "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif,.TIF,.tiff,.grib2,.GRIB2",
         "GDAL_CACHEMAX": "200",  # 200 mb
         "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
         "GDAL_INGESTED_BYTES_AT_OPEN": "32768",


### PR DESCRIPTION
### Issue

N/A

### What?

- Added `.grib2,.GRIB2` to `CPL_VSIL_CURL_ALLOWED_EXTENSIONS` in `vedaRasterSettings.env`
- Added the same setting in `docker-compose.yml` under the `raster` service

### Why?

Currently only tiff extensions are whitelisted by GDAL, so when trying to stream GRIB2 files directly to the Raster API, it throws an error (see testing url below). Some VEDA tools (eg. the fire tool) currently stream GRIB2 files to TiTiler for fetching wind information but still rely on the public demo TiTiler instance. We’d like to switch them over to the openveda raster API and for that grib2 support is needed.

### Testing?

Tested locally:

- Ran `docker compose up`
- Verified `.grib2` requests were rejected before the change and succeed after the update using this url in Chrome:
`http://localhost:8082/cog/preview.png?rescale=-127,128&url=vrt:///vsicurl/https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.20250512/conus/hrrr.t06z.wrfsfcf04.grib2?bands=10,11&format=png`
