### PR TITLE
fix(stac-validation): upgrade pystac version and override pystac default stac version

### DIFF
--- a/stac_api/infrastructure/config.py
+++ b/stac_api/infrastructure/config.py
@@ -58,6 +58,10 @@ class vedaSTACSettings(BaseSettings):
         False,
         description="Boolean to disable default API gateway endpoints for stac, raster, and ingest APIs. Defaults to false.",
     )
+    pystac_stac_version_override: Optional[str] = Field(
+        "1.0.0",
+        description="Stac version override for Pystac validations https://pystac.readthedocs.io/en/stable/api/version.html",
+    )
 
     @model_validator(mode="before")
     def check_transaction_fields(cls, values):

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -53,6 +53,7 @@ class StacApiLambdaConstruct(Construct):
             ),
             "DB_MIN_CONN_SIZE": "0",
             "DB_MAX_CONN_SIZE": "1",
+            "PYSTAC_STAC_VERSION_OVERRIDE": veda_stac_settings.pystac_stac_version_override,
             **{k.upper(): v for k, v in veda_stac_settings.env.items()},
         }
 

--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -19,7 +19,7 @@ inst_reqs = [
     "pygeoif<=0.8",  # newest release (1.0+ / 09-22-2022) breaks a number of other geo libs
     "aws-lambda-powertools>=1.18.0",
     "aws_xray_sdk>=2.6.0,<3",
-    "pystac[validation]==1.10.1",
+    "pystac[validation]>=1.14.0",
     "pydantic>2",
     "eoapi-auth-utils==0.3.0",
 ]


### PR DESCRIPTION
## What
- STAC metadata validations are currently failing due to a import error that is corrected in a newer version of pystac https://github.com/NASA-IMPACT/veda-backend/issues/527. 
- The default stac version in the updated pystac is higher than the stac version of our records so additional configuration was added with a default value of the current catalog's stac version.

## How tested
The tests are now passing on the github runner: https://github.com/NASA-IMPACT/veda-backend/actions/runs/17841567081/job/50732312624
