### PR TITLE
feat: cache collections lookup

### DIFF
--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -9,6 +9,7 @@ with open("README.md") as f:
 
 inst_reqs = [
     "boto3",
+    "cachetools>=6.2.1",
     "stac-fastapi.api~=5.0",
     "stac-fastapi.types~=5.0",
     "stac-fastapi.extensions~=5.0",

--- a/stac_api/runtime/src/filters.py
+++ b/stac_api/runtime/src/filters.py
@@ -4,6 +4,7 @@ import dataclasses
 import logging
 from typing import Any, Optional
 
+import cachetools
 import httpx
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ class ItemFilter:
     def __post_init__(self):
         """Initialize the ItemFilter"""
         self.client = httpx.AsyncClient(base_url=self.api_url)
+        self.cache = cachetools.TTLCache(ttl=60, maxsize=1000)
 
     async def __call__(self, context: dict[str, Any]) -> str:
         """If tenant is present on request, filter Items by Collection IDs available to that tenant"""
@@ -54,7 +56,7 @@ class ItemFilter:
             f"collection = '{collection_id}'" for collection_id in collection_ids
         )
 
-    # TODO: Memoize this with expiration
+    @cachetools.cachedmethod(lambda self: self.cache)
     async def get_tenant_collections(self, tenant: str) -> list[str]:
         """Fetch IDs of collections visible to a tenant"""
         logger.debug(


### PR DESCRIPTION
### What?

Cache collection lookups in the items filter factory

### Why?

When we fetch a tenant's collection to build an items filter, we should cache that value to reduce pressure on the API

### Testing?

- Relevant testing details

