### PR TITLE
build: speed up raster and stac lambda builds

### DIFF
--- a/app.py
+++ b/app.py
@@ -119,22 +119,22 @@ ingestor_config = ingest_config(
     git_sha=git_sha,
 )
 
-ingest_api = ingest_api_construct(
-    veda_stack,
-    "ingest-api",
-    config=ingestor_config,
-    db_secret=database.pgstac.secret,
-    db_vpc=vpc.vpc,
-)
-
-ingestor = ingestor_construct(
-    veda_stack,
-    "IngestorConstruct",
-    config=ingestor_config,
-    table=ingest_api.table,
-    db_secret=database.pgstac.secret,
-    db_vpc=vpc.vpc,
-)
+# ingest_api = ingest_api_construct(
+#    veda_stack,
+#    "ingest-api",
+#    config=ingestor_config,
+#    db_secret=database.pgstac.secret,
+#    db_vpc=vpc.vpc,
+# )
+#
+# ingestor = ingestor_construct(
+#    veda_stack,
+#    "IngestorConstruct",
+#    config=ingestor_config,
+#    table=ingest_api.table,
+#    db_secret=database.pgstac.secret,
+#    db_vpc=vpc.vpc,
+# )
 
 for key, value in {
     "Project": veda_app_settings.app_name,

--- a/app.py
+++ b/app.py
@@ -119,22 +119,22 @@ ingestor_config = ingest_config(
     git_sha=git_sha,
 )
 
-# ingest_api = ingest_api_construct(
-#    veda_stack,
-#    "ingest-api",
-#    config=ingestor_config,
-#    db_secret=database.pgstac.secret,
-#    db_vpc=vpc.vpc,
-# )
-#
-# ingestor = ingestor_construct(
-#    veda_stack,
-#    "IngestorConstruct",
-#    config=ingestor_config,
-#    table=ingest_api.table,
-#    db_secret=database.pgstac.secret,
-#    db_vpc=vpc.vpc,
-# )
+ingest_api = ingest_api_construct(
+   veda_stack,
+   "ingest-api",
+   config=ingestor_config,
+   db_secret=database.pgstac.secret,
+   db_vpc=vpc.vpc,
+)
+
+ingestor = ingestor_construct(
+   veda_stack,
+   "IngestorConstruct",
+   config=ingestor_config,
+   table=ingest_api.table,
+   db_secret=database.pgstac.secret,
+   db_vpc=vpc.vpc,
+)
 
 for key, value in {
     "Project": veda_app_settings.app_name,

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -81,11 +81,11 @@ class BootstrapPgStac(Construct):
 
         # Allow lambda to...
         # read new user secret
-         self.secret.grant_read(handler)
+        self.secret.grant_read(handler)
         # read database secret
-         database.secret.grant_read(handler)
+        database.secret.grant_read(handler)
         # connect to database
-         database.connections.allow_from(handler, port_range=aws_ec2.Port.tcp(5432))
+        database.connections.allow_from(handler, port_range=aws_ec2.Port.tcp(5432))
 
         self.connections = database.connections
 

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -44,20 +44,20 @@ class BootstrapPgStac(Construct):
         pgstac_version = veda_db_settings.pgstac_version
         veda_schema_version = veda_db_settings.schema_version
 
-        handler = aws_lambda.Function(
-            self,
-            "lambda",
-            handler="handler.handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
-            code=aws_lambda.Code.from_docker_build(
-                path=os.path.abspath("./"),
-                file="database/runtime/Dockerfile",
-                build_args={"PGSTAC_VERSION": pgstac_version},
-            ),
-            timeout=Duration.minutes(5),
-            vpc=database.vpc,
-            log_retention=aws_logs.RetentionDays.ONE_WEEK,
-        )
+        # handler = aws_lambda.Function(
+        #    self,
+        #    "lambda",
+        #    handler="handler.handler",
+        #    runtime=aws_lambda.Runtime.PYTHON_3_12,
+        #    code=aws_lambda.Code.from_docker_build(
+        #        path=os.path.abspath("./"),
+        #        file="database/runtime/Dockerfile",
+        #        build_args={"PGSTAC_VERSION": pgstac_version},
+        #    ),
+        #    timeout=Duration.minutes(5),
+        #    vpc=database.vpc,
+        #    log_retention=aws_logs.RetentionDays.ONE_WEEK,
+        # )
 
         self.secret = aws_secretsmanager.Secret(
             self,
@@ -81,28 +81,28 @@ class BootstrapPgStac(Construct):
 
         # Allow lambda to...
         # read new user secret
-        self.secret.grant_read(handler)
-        # read database secret
-        database.secret.grant_read(handler)
-        # connect to database
-        database.connections.allow_from(handler, port_range=aws_ec2.Port.tcp(5432))
+        # self.secret.grant_read(handler)
+        ## read database secret
+        # database.secret.grant_read(handler)
+        ## connect to database
+        # database.connections.allow_from(handler, port_range=aws_ec2.Port.tcp(5432))
 
         self.connections = database.connections
 
-        CustomResource(
-            scope=scope,
-            id="bootstrapper",
-            service_token=handler.function_arn,
-            properties={
-                # By setting pgstac_version in the properties assures
-                # that Create/Update events will be passed to the service token
-                "pgstac_version": pgstac_version,
-                "conn_secret_arn": database.secret.secret_arn,
-                "new_user_secret_arn": self.secret.secret_arn,
-                "veda_schema_version": veda_schema_version,
-            },
-            removal_policy=RemovalPolicy.RETAIN,  # This retains the custom resource (which doesn't really exist), not the database
-        )
+        # CustomResource(
+        #    scope=scope,
+        #    id="bootstrapper",
+        #    service_token=handler.function_arn,
+        #    properties={
+        #        # By setting pgstac_version in the properties assures
+        #        # that Create/Update events will be passed to the service token
+        #        "pgstac_version": pgstac_version,
+        #        "conn_secret_arn": database.secret.secret_arn,
+        #        "new_user_secret_arn": self.secret.secret_arn,
+        #        "veda_schema_version": veda_schema_version,
+        #    },
+        #    removal_policy=RemovalPolicy.RETAIN,  # This retains the custom resource (which doesn't really exist), not the database
+        # )
 
 
 # https://github.com/developmentseed/eoAPI/blob/master/deployment/cdk/app.py

--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -13,6 +13,7 @@ from aws_cdk import (
     aws_lambda,
     aws_logs,
 )
+from aws_cdk.aws_ecr_assets import Platform
 from constructs import Construct
 
 from .config import veda_raster_settings
@@ -37,17 +38,15 @@ class RasterApiLambdaConstruct(Construct):
         # TODO config
         stack_name = Stack.of(self).stack_name
 
-        veda_raster_function = aws_lambda.Function(
+        veda_raster_function = aws_lambda.DockerImageFunction(
             self,
             "lambda",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
-            code=aws_lambda.Code.from_docker_build(
-                path=os.path.abspath(code_dir),
+            code=aws_lambda.DockerImageCode.from_image_asset(
+                directory=os.path.abspath(code_dir),
                 file="raster_api/runtime/Dockerfile",
-                platform="linux/amd64",
+                platform=Platform.LINUX_AMD64,
             ),
             vpc=vpc,
-            handler="handler.handler",
             memory_size=veda_raster_settings.memory,
             timeout=Duration.seconds(veda_raster_settings.timeout),
             log_retention=aws_logs.RetentionDays.ONE_WEEK,

--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -1,25 +1,74 @@
-FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
+ARG PYTHON_VERSION=3.12
 
-RUN dnf install -y gcc-c++
+# Stage 1: application and dependencies
+FROM public.ecr.aws/lambda/python:${PYTHON_VERSION} AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+RUN dnf install -y gcc-c++ && dnf clean all
 
 WORKDIR /tmp
 
 COPY raster_api/runtime /tmp/raster
-RUN pip install mangum /tmp/raster["psycopg-binary"] -t /asset --no-binary pydantic
+
+# we could have a `uv export` here, if we converted the project format
+RUN uv pip install mangum /tmp/raster["psycopg-binary"] --target /deps --no-binary pydantic
+
+RUN <<EOF
+uv pip install \
+  --compile-bytecode \
+  --no-binary pydantic \
+  --target /deps \
+  --no-cache-dir \
+  --disable-pip-version-check \
+  /tmp/raster["psycopg-binary"] \
+  mangum
+EOF
 RUN rm -rf /tmp/raster
-RUN cp /usr/lib64/libexpat.so.1 /asset/
 
-# # Reduce package size and remove useless files
-RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;
-RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
-RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
-RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
+# Aggressive cleanup to minimize size and optimize for Lambda container
+# Clean up app dependencies in /deps
+WORKDIR /deps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN <<EOF
+# Convert .pyc files and remove source .py files for faster cold starts
+find . -type f -name '*.pyc' | while read -r f; do n="$(echo "$f" | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//')"; cp "$f" "$n"; done
+find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+# Remove unnecessary files for Lambda runtime
+find . -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+find . -type d -a -name 'test' -print0 | xargs -0 rm -rf
+rm -rf numpy/doc/ bin/ geos_license Misc/
+# Remove unnecessary locale and documentation files
+find . -name '*.mo' -delete
+find . -name '*.po' -delete
+find . -name 'LICENSE*' -delete
+find . -name 'README*' -delete
+find . -name '*.md' -delete
+# Strip debug symbols from shared libraries (preserve numpy.libs)
+find . -type f -name '*.so*' -not -path "*/numpy.libs/*" -exec strip --strip-unneeded {} \; 2>/dev/null || true
+EOF
 
-COPY raster_api/runtime/handler.py /asset/handler.py
-RUN dnf remove -y gcc-c++
+# Stage 2: Final runtime stage - minimal Lambda image optimized for container runtime
+FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
-WORKDIR /asset
+ENV PYTHONUNBUFFERED=1 \
+  PYTHONDONTWRITEBYTECODE=1
+
+COPY --from=builder /deps ${LAMBDA_RUNTIME_DIR}/
+COPY --from=builder /usr/lib64/libexpat.so.1 ${LAMBDA_RUNTIME_DIR}/
+COPY infrastructure/aws/lambda/handler.py ${LAMBDA_RUNTIME_DIR}/
+COPY raster_api/runtime/handler.py ${LAMBDA_RUNTIME_DIR}/
+
+
+RUN <<EOF
+chmod 644 "${LAMBDA_RUNTIME_DIR}"/handler.py
+chmod -R 755 /opt/
+# Pre-compile the handler for faster cold starts
+python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.py', doraise=True)"
+# Create cache directories with proper permissions
+mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
+EOF
+
 RUN python -c "from handler import handler; print('All Good')"
 
-CMD ["echo", "hello world"]
+CMD ["handler.handler"]

--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -68,6 +68,4 @@ python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.
 mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
 EOF
 
-RUN python -c "from handler import handler; print('All Good')"
-
 CMD ["handler.handler"]

--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -56,7 +56,6 @@ ENV PYTHONUNBUFFERED=1 \
 
 COPY --from=builder /deps ${LAMBDA_RUNTIME_DIR}/
 COPY --from=builder /usr/lib64/libexpat.so.1 ${LAMBDA_RUNTIME_DIR}/
-COPY infrastructure/aws/lambda/handler.py ${LAMBDA_RUNTIME_DIR}/
 COPY raster_api/runtime/handler.py ${LAMBDA_RUNTIME_DIR}/
 
 

--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -68,4 +68,4 @@ python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.
 mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
 EOF
 
-CMD ["handler.handler"]
+CMD ["handler.lambda_handler"]

--- a/raster_api/runtime/handler.py
+++ b/raster_api/runtime/handler.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+from typing import Any, Dict
 
 from mangum import Mangum
 from src.app import app
@@ -36,3 +37,7 @@ handler = tracer.capture_lambda_handler(handler)
 handler = logger.inject_lambda_context(handler, clear_state=True)
 # Add metrics last to properly flush metrics.
 handler = metrics.log_metrics(handler, capture_cold_start_metric=True)
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Lambda handler with container-specific optimizations and OTEL tracing."""
+    return handler(event, context)

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -12,6 +12,7 @@ from aws_cdk import (
     aws_lambda,
     aws_logs,
 )
+from aws_cdk.aws_ecr_assets import Platform
 from constructs import Construct
 
 from .config import veda_stac_settings
@@ -67,14 +68,13 @@ class StacApiLambdaConstruct(Construct):
                 veda_stac_settings.openid_configuration_url
             )
 
-        lambda_function = aws_lambda.Function(
+        lambda_function = aws_lambda.DockerImageFunction(
             self,
             "lambda",
-            handler="handler.handler",
-            runtime=aws_lambda.Runtime.PYTHON_3_12,
-            code=aws_lambda.Code.from_docker_build(
-                path=os.path.abspath(code_dir),
+            code=aws_lambda.DockerImageCode.from_image_asset(
+                directory=os.path.abspath(code_dir),
                 file="stac_api/runtime/Dockerfile",
+                platform=Platform.LINUX_AMD64,
             ),
             vpc=vpc,
             memory_size=veda_stac_settings.memory,

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /tmp
 COPY stac_api/runtime /tmp/stac
 
 # we could have a `uv export` here, if we converted the project format
-RUN uv pip install "mangum" "plpygis>=0.2.1" /tmp/stac["psycopg-binary"] --target /deps --no-binary pydantic
+RUN uv pip install mangum "plpygis>=0.2.1" /tmp/stac["psycopg-binary"] --target /deps --no-binary pydantic
 RUN rm -rf /tmp/stac
 
 WORKDIR /deps

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -43,7 +43,6 @@ ENV PYTHONUNBUFFERED=1 \
 
 COPY --from=builder /deps ${LAMBDA_RUNTIME_DIR}/
 COPY --from=builder /usr/lib64/libexpat.so.1 ${LAMBDA_RUNTIME_DIR}/
-COPY infrastructure/aws/lambda/handler.py ${LAMBDA_RUNTIME_DIR}/
 COPY stac_api/runtime/handler.py ${LAMBDA_RUNTIME_DIR}/
 
 

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -55,6 +55,4 @@ python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.
 mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
 EOF
 
-RUN python -c "from handler import handler; print('All Good')"
-
 CMD ["handler.handler"]

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -1,18 +1,61 @@
-FROM --platform=linux/amd64 public.ecr.aws/sam/build-python3.12:latest
+ARG PYTHON_VERSION=3.12
+
+# Stage 1: application and dependencies
+FROM public.ecr.aws/lambda/python:${PYTHON_VERSION} AS builder
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+RUN dnf install -y gcc-c++ && dnf clean all
 
 WORKDIR /tmp
 
 COPY stac_api/runtime /tmp/stac
 
-RUN pip install "mangum" "plpygis>=0.2.1" /tmp/stac -t /asset --no-binary pydantic
+# we could have a `uv export` here, if we converted the project format
+RUN uv pip install "mangum" "plpygis>=0.2.1" /tmp/stac["psycopg-binary"] --target /deps --no-binary pydantic
 RUN rm -rf /tmp/stac
 
-# Reduce package size and remove useless files
-RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;
-RUN cd /asset && find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
-RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
-RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+WORKDIR /deps
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN <<EOF
+# Convert .pyc files and remove source .py files for faster cold starts
+find . -type f -name '*.pyc' | while read -r f; do n="$(echo "$f" | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//')"; cp "$f" "$n"; done
+find . -type d -a -name '__pycache__' -print0 | xargs -0 rm -rf
+find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
+# Remove unnecessary files for Lambda runtime
+find . -type d -a -name 'tests' -print0 | xargs -0 rm -rf
+find . -type d -a -name 'test' -print0 | xargs -0 rm -rf
+rm -rf numpy/doc/ bin/ geos_license Misc/
+# Remove unnecessary locale and documentation files
+find . -name '*.mo' -delete
+find . -name '*.po' -delete
+find . -name 'LICENSE*' -delete
+find . -name 'README*' -delete
+find . -name '*.md' -delete
+# Strip debug symbols from shared libraries (preserve numpy.libs)
+find . -type f -name '*.so*' -not -path "*/numpy.libs/*" -exec strip --strip-unneeded {} \; 2>/dev/null || true
+EOF
 
-COPY stac_api/runtime/handler.py /asset/handler.py
+# Stage 2: Final runtime stage - minimal Lambda image optimized for container runtime
+FROM public.ecr.aws/lambda/python:${PYTHON_VERSION}
 
-CMD ["echo", "hello world"]
+ENV PYTHONUNBUFFERED=1 \
+  PYTHONDONTWRITEBYTECODE=1
+
+COPY --from=builder /deps ${LAMBDA_RUNTIME_DIR}/
+COPY --from=builder /usr/lib64/libexpat.so.1 ${LAMBDA_RUNTIME_DIR}/
+COPY infrastructure/aws/lambda/handler.py ${LAMBDA_RUNTIME_DIR}/
+COPY stac_api/runtime/handler.py ${LAMBDA_RUNTIME_DIR}/
+
+
+RUN <<EOF
+chmod 644 "${LAMBDA_RUNTIME_DIR}"/handler.py
+chmod -R 755 /opt/
+# Pre-compile the handler for faster cold starts
+python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.py', doraise=True)"
+# Create cache directories with proper permissions
+mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
+EOF
+
+RUN python -c "from handler import handler; print('All Good')"
+
+CMD ["handler.handler"]

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -55,4 +55,4 @@ python -c "import py_compile; py_compile.compile('${LAMBDA_RUNTIME_DIR}/handler.
 mkdir -p /tmp/.cache && chmod 777 /tmp/.cache
 EOF
 
-CMD ["handler.handler"]
+CMD ["handler.lambda_handler"]

--- a/stac_api/runtime/handler.py
+++ b/stac_api/runtime/handler.py
@@ -5,6 +5,7 @@ import logging
 from mangum import Mangum
 from src.app import app
 from src.monitoring import logger, metrics, tracer
+from typing import Any, Dict
 
 logging.getLogger("mangum.lifespan").setLevel(logging.ERROR)
 logging.getLogger("mangum.http").setLevel(logging.ERROR)
@@ -18,3 +19,7 @@ handler = tracer.capture_lambda_handler(handler)
 handler = logger.inject_lambda_context(handler, clear_state=True)
 # Add metrics last to properly flush metrics.
 handler = metrics.log_metrics(handler, capture_cold_start_metric=True)
+
+def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Lambda handler with container-specific optimizations and OTEL tracing."""
+    return handler(event, context)


### PR DESCRIPTION
### Why?

`cdk synth` and `cdk diff` take a long time (5-15 minutes, depending on local resources and cache hits) because in order to interact with the CDK stack, the `app.synth()` call must build all of the docker assets we use. By changing how we bundle Docker assets, we can dramatically improve synth (and possibly deploy) times.

### What?

- @hrodmn made this work for [titiler-cmr](https://github.com/developmentseed/titiler-cmr/pull/81), and it carries over to our lambdas really well
- Dockerfiles are refactored, and produce small, optimized images that automatically go into ECR
- Ingest API excluded, because we use the same image with different entrypoints, and I haven't worked out how to integrate that yet
- DB bootstrapper is excluded because it's structured and executed differently.

Eventually we could go even further, by managing the ECR images ourselves. This would allow us to update a specific service without deploying the full stack (which would definitely accelerate deployments)

### Testing?

`time cdk synth` before (on `develop`)
<img width="167" height="61" alt="Pasted image 20251016214746" src="https://github.com/user-attachments/assets/ad8a8826-26a6-44ad-80b4-8f3f3145a25b" />

`time cdk synth` after
<img width="182" height="60" alt="Pasted image 20251016214132" src="https://github.com/user-attachments/assets/815fe512-ade2-4094-8358-22a75c3f258b" />

Deployment to mcp-test and uah-sit (not done yet)
- [x] uah (to test runtimes)
- [ ] mcp (to test ECR deployment and permissions)