### PR TITLE
fix: upgrade stac-fastapi to v6.1.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - VEDA_STAC_ROOT_PATH=/api/stac
       - VEDA_STAC_OPENID_CONFIGURATION_URL=http://localhost:8888/.well-known/openid-configuration
       - VEDA_STAC_OPENID_CONFIGURATION_INTERNAL_URL=http://oidc:8888/.well-known/openid-configuration
-      - VEDA_STAC_ENABLE_TRANSACTIONS=False
+      - VEDA_STAC_ENABLE_TRANSACTIONS=True
       - VEDA_STAC_GIT_SHA=local123
       - VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,11 @@ services:
       # https://github.com/tiangolo/uvicorn-gunicorn-docker#max_workers
       # - MAX_WORKERS=10
       # Postgres connection
-      - POSTGRES_USER=username
-      - POSTGRES_PASS=password
-      - POSTGRES_DBNAME=postgis
-      - POSTGRES_HOST_READER=database
-      - POSTGRES_HOST_WRITER=database
-      - POSTGRES_PORT=5432
+      - PGUSER=username
+      - PGPASSWORD=password
+      - PGDATABASE=postgis
+      - PGHOST=database
+      - PGPORT=5432
       - DB_MIN_CONN_SIZE=1
       - DB_MAX_CONN_SIZE=10
       # https://github.com/developmentseed/eoAPI/issues/16

--- a/stac_api/infrastructure/construct.py
+++ b/stac_api/infrastructure/construct.py
@@ -42,9 +42,11 @@ class StacApiLambdaConstruct(Construct):
             "VEDA_STAC_PROJECT_DESCRIPTION": veda_stac_settings.project_description,
             "VEDA_STAC_ROOT_PATH": veda_stac_settings.stac_root_path,
             "VEDA_STAC_STAGE": stage,
-            "VEDA_STAC_CLIENT_ID": veda_stac_settings.keycloak_stac_api_client_id
-            if veda_stac_settings.keycloak_stac_api_client_id
-            else "",
+            "VEDA_STAC_CLIENT_ID": (
+                veda_stac_settings.keycloak_stac_api_client_id
+                if veda_stac_settings.keycloak_stac_api_client_id
+                else ""
+            ),
             "VEDA_STAC_OPENID_CONFIGURATION_URL": str(
                 veda_stac_settings.openid_configuration_url
             ),

--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -10,10 +10,10 @@ with open("README.md") as f:
 inst_reqs = [
     "boto3",
     "async-lru>=2.0.5",
-    "stac-fastapi.api~=5.0",
-    "stac-fastapi.types~=5.0",
-    "stac-fastapi.extensions~=5.0",
-    "stac-fastapi.pgstac>=5.0.3,<6.0",
+    "stac-fastapi.api~=6.1",
+    "stac-fastapi.types~=6.1",
+    "stac-fastapi.extensions~=6.1",
+    "stac-fastapi.pgstac~=6.1",
     "jinja2>=2.11.2,<4.0.0",
     "starlette-cramjam>=0.4.0",
     "importlib_resources>=1.1.0;python_version<='3.11'",  # https://github.com/cogeotiff/rio-tiler/pull/379

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -51,7 +51,11 @@ tiles_settings = TilesApiSettings()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Get a database connection on startup, close it on shutdown."""
-    await connect_to_db(app, postgres_settings=api_settings.postgres_settings)
+    await connect_to_db(
+        app,
+        postgres_settings=api_settings.postgres_settings,
+        add_write_connection_pool=True,
+    )
     yield
     await close_db_connection(app)
 

--- a/stac_api/runtime/src/config.py
+++ b/stac_api/runtime/src/config.py
@@ -116,12 +116,11 @@ class _ApiSettings(Settings):
         if self.pgstac_secret_arn:
             secret = get_secret_dict(self.pgstac_secret_arn)
             return PostgresSettings(
-                postgres_host_reader=secret["host"],
-                postgres_host_writer=secret["host"],
-                postgres_dbname=secret["dbname"],
-                postgres_user=secret["username"],
-                postgres_pass=secret["password"],
-                postgres_port=secret["port"],
+                pghost=secret["host"],
+                pgdatabase=secret["dbname"],
+                pguser=secret["username"],
+                pgpassword=secret["password"],
+                pgport=secret["port"],
             )
         return PostgresSettings()
 

--- a/stac_api/runtime/src/core.py
+++ b/stac_api/runtime/src/core.py
@@ -1,4 +1,5 @@
 """CoreCrudClient extensions for the VEDA STAC API."""
+
 from typing import Any, Dict, Union
 
 from stac_fastapi.pgstac.core import CoreCrudClient

--- a/stac_api/runtime/src/links.py
+++ b/stac_api/runtime/src/links.py
@@ -1,4 +1,5 @@
 """A module for injecting links to STAC entries"""
+
 from typing import Any, Dict
 from urllib.parse import urljoin
 

--- a/stac_api/runtime/src/monitoring.py
+++ b/stac_api/runtime/src/monitoring.py
@@ -93,7 +93,7 @@ class ObservabilityMiddleware:
             if message["type"] == "http.response.start":
                 status_holder["status"] = message.get("status", 500)
                 # If Content-Length is set, remember it; otherwise we’ll sum body chunks
-                for (h, v) in message.get("headers", []) or []:
+                for h, v in message.get("headers", []) or []:
                     if h.lower() == b"content-length":
                         try:
                             resp_size_holder["bytes"] = int(v.decode("latin1"))

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -326,7 +326,7 @@ async def app():
     """
     from src.app import app
 
-    await connect_to_db(app)
+    await connect_to_db(app, add_write_connection_pool=True)
     yield app
     await close_db_connection(app)
 

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -239,12 +239,11 @@ def test_environ():
     os.environ["VEDA_STAC_ROOT_PATH"] = "/api/stac"
 
     # Config mocks
-    os.environ["POSTGRES_USER"] = "username"
-    os.environ["POSTGRES_PASS"] = "password"
-    os.environ["POSTGRES_DBNAME"] = "postgis"
-    os.environ["POSTGRES_HOST_READER"] = "0.0.0.0"
-    os.environ["POSTGRES_HOST_WRITER"] = "0.0.0.0"
-    os.environ["POSTGRES_PORT"] = "5439"
+    os.environ["PGUSER"] = "username"
+    os.environ["PGPASSWORD"] = "password"
+    os.environ["PGDATABASE"] = "postgis"
+    os.environ["PGHOST"] = "0.0.0.0"
+    os.environ["PGPORT"] = "5439"
 
 
 def override_jwks_client():


### PR DESCRIPTION
### Issue

#497 

### What?

- Update PG env var names
- Add flag to create writer connection pool for transactions
- Add a bunch of new tests for transactions, which also makes local OIDC work better

There were inconsistencies between how unit tests were running and how the actual service was behaving with the transactions changes. I had a really hard time getting meaningful errors out of the unit tests, so I converted them into integration tests that run against the `docker compose` services and make use of the existing auth integrations we have there. This was way more promising and has me feeling confident about the changes, but I'm still not sure what's wrong with the unit tests.

### Testing?

- ~Tests pass~ Unit tests fail 🤔, manual + integration tests pass
- Manually tested transactions, since the new default behaviour is to enable transactions with a new `stac-fastapi` environment variable. `veda-backend` already has a variable to enable the extension, which duplicates this functionality. We can continue to use this approach without breaking existing instances, or we can migrate to the alternative `stac-fastapi` variable.

