### PR TITLE
chore: upgrade stac-auth-proxy to v0.11.1

### DIFF
--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -22,7 +22,7 @@ inst_reqs = [
     "aws_xray_sdk>=2.6.0,<3",
     "pystac[validation]>=1.14.0",
     "pydantic>2",
-    "stac-auth-proxy==0.11.1",
+    "stac-auth-proxy==0.11.1rc2",
 ]
 
 extra_reqs = {

--- a/stac_api/runtime/setup.py
+++ b/stac_api/runtime/setup.py
@@ -22,7 +22,7 @@ inst_reqs = [
     "aws_xray_sdk>=2.6.0,<3",
     "pystac[validation]>=1.14.0",
     "pydantic>2",
-    "stac-auth-proxy==0.10.0",
+    "stac-auth-proxy==0.11.1",
 ]
 
 extra_reqs = {


### PR DESCRIPTION

### What?

This upgrades stac auth proxy to to version that contains enhanced type safety https://github.com/developmentseed/stac-auth-proxy/pull/125 
### Why?

When we were testing migrating EIC staging data, we had a couple collections that failed to migrate due to invalid fields https://github.com/NASA-IMPACT/veda-architecture/issues/688


