### PR TITLE
feat: create resource extractors for RPT (requesting party token) 

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Stac-api extensions unit tests
         run: python -m pytest stac_api/runtime/tests/ --asyncio-mode=auto -vv -s
 
+      - name: Auth unit tests
+        run: python -m pytest common/auth/tests/ -vv -s
+
       - name: Stop services
         run: docker compose stop
 

--- a/common/auth/README.md
+++ b/common/auth/README.md
@@ -12,8 +12,7 @@ The `KeycloakPDPClient` enables applications to:
 
 - Request a RPT (Requesting Party Token) from Keycloak
 - Check user permissions for specific resources and scopes
-- Extract tenant information from user tokens
-- Get lists of tenants where users have create/update access
+- Extract tenant information from user token claims to help build the list of tenants where users have create/update access (for example, for the writable-tenants API endpoint)
 
 ### Installation
 
@@ -93,6 +92,7 @@ tenants = pdp_client.get_tenants_with_create_update_access(
 # Returns: ["tenant1", "tenant2", "public"]
 ```
 
+
 #### `check_permission(access_token, resource_id, scope)`
 
 Checks if a user has a specific permission for a resource.
@@ -153,10 +153,42 @@ Examples:
 
 ### Token Claims
 
-The client extracts tenant information from JWT token claims. It looks for tenants in:
+The `KeycloakPDPClient` extracts tenant names from the user's JWT when building the list of tenants the user can write to (for example, in `get_tenants_with_create_update_access` and the **GET `/auth/tenants/writable`** endpoint). This extraction is used only to **return** a list of writable tenants.
 
-- `group_membership.tenants` array
-- `groups` array
+Tenant names are read from these claims:
+
+- `group_membership.tenants` array – an array of group path strings
+- `groups` array – an array of group path strings
+
+Each group value is expected to contain the segment `/Tenants/`. The tenant name is taken as the third path component when splitting the string on `/`. For example:
+
+- `"/Tenants/veda"`, the tenant extracted is `"veda"`
+- `"/realm/role/Tenants/veda"`, the tenant extracted is  `"veda"`
+
+### Resource Extractor Use Cases
+
+This section summarizes how the resource extractor functions in `veda_auth.resource_extractors` derive the **Keycloak resource ID** for different API calls.
+
+#### STAC API (`extract_stac_resource_id` function)
+
+| Path pattern                           | Methods                           |  Resource          | Tenant source for resource ID                         | Resource ID returned (shape)                     | Notes                                                                                     |
+|----------------------------------------------------|-----------------------------------|-------------------------------|-------------------------------------------------------|--------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `/collections`                                     | `POST`                            | Create collection             | Request body field `eic:tenant` (or `TENANT_FIELD`), or public | `stac:collection:{tenant}:*` or public | STAC create collection; same body-based extraction as PUT/PATCH.                          |
+| `/collections/{collection_id}`                     | `GET`, `DELETE`   | Single collection             | `request.state.tenant` (from URL), or public fallback | `stac:collection:{tenant}:*` or public           | When the URL contains a tenant, the tenant comes from the URL path, otherwise it falls back to `public`.    |
+| `/collections/{collection_id}`                     | `PUT`, `PATCH`                    | Single collection (write)     | Request body field `eic:tenant` (or `TENANT_FIELD`), or public | `stac:collection:{tenant}:*` or public | It reads the JSON body to determine tenant, if empty body it returns `None`.                    |
+| `/collections/{collection_id}/items/{item_id}`     | All methods                       | Single item                   | `request.state.tenant` (from URL), or public fallback | `stac:item:{tenant}:*` or public                | Item body is **not** read for tenant; only URL-derived tenant (or public) is used.        |
+| `/collections/{collection_id}/items`               | `GET`, `POST`                     | Items under a collection      | `request.state.tenant` (from URL), or public fallback | `stac:collection:{tenant}:*` or public           | Collection-scoped resource ID for listing/creating items.                                 |
+| `/collections/{collection_id}/bulk_items`          | `POST`                            | Bulk item operations          | `request.state.tenant` (from URL), or public fallback | `stac:collection:{tenant}:*` or public           | Bulk operations are treated as collection-scoped actions.                                 |
+| Any path containing `/queryables` or `/search`     | Any                               | Query/search endpoints        | _n/a_                                                 | `None`                                           | Resource ID is not extracted for query/search endpoints.                                  |
+
+\* For methods on `/collections/{collection_id}` other than `PUT`/`PATCH`, the extractor uses the URL-derived tenant (or public) via `_stac_collection_resource_id`.
+
+#### Ingest API (`extract_ingest_resource_id` function)
+
+| Path pattern          | Method | Resource      | Tenant source for resource ID                          | Resource ID returned (shape)            | Notes                                                                                   |
+|------------------------------------|--------|---------------------------|--------------------------------------------------------|-----------------------------------------|-----------------------------------------------------------------------------------------|
+| `/collections`                     | `POST` | Create collection request | Request body field `eic:tenant` (or `TENANT_FIELD`), or public | `stac:collection:{tenant}:*` or public | Uses the same body-based extraction helper as the STAC collection write case.           |
+| `/collections/{collection_id}`     | `DELETE` | Delete collection        | _none_ (no tenant used)                                | `collection:{collection_id}`           | Ingest delete uses an ID-scoped resource (`collection:{id}`) without tenant component. Tenant-aware deletes will be handled in Phase 2. |
 
 ### See Also
 

--- a/common/auth/README.md
+++ b/common/auth/README.md
@@ -136,17 +136,20 @@ Requests an RPT (Requesting Party Token) from Keycloak containing the user's per
 ### Resource Identifier Format
 
 Resources in Keycloak should follow this naming convention:
-```
+
+```json
 stac:{resource_type}:{tenant_name}
 ```
 
-They are defined by the resource server configuration settings. For more examples, see [veda-keycloak config](https://github.com/NASA-IMPACT/veda-keycloak/blob/main/keycloak-config-cli/config/dev/veda.yaml#L331)
+These resource definitions must match the resources configured in Keycloak's authorization services.
+
+For the actual resource definitions used in VEDA, see the [veda-keycloak configuration](https://github.com/NASA-IMPACT/veda-keycloak/blob/main/keycloak-config-cli/config/dev/veda.yaml#L334).
 
 Examples:
 
-- `stac:collection:tenant1`
-- `stac:item:tenant2`
-- `stac:collection:public`
+- `stac:collection:tenant1:*`
+- `stac:item:tenant2:*`
+- `stac:collection:public:*`
 
 ### Token Claims
 

--- a/common/auth/tests/test_resource_extractors.py
+++ b/common/auth/tests/test_resource_extractors.py
@@ -94,21 +94,6 @@ class TestExtractCollectionResourceIdFromPostBody:
         result = await _extract_collection_resource_id_from_post_body(request)
         assert result is None
 
-    @pytest.mark.asyncio
-    async def test_extract_tenant_from_properties(self):
-        """Test extracting resource ID when tenant is in properties"""
-        body_data = {
-            "id": "test-collection",
-            "properties": {"eic:tenant": "test-tenant"},
-        }
-        test_body = json.dumps(body_data).encode("utf-8")
-
-        request = MagicMock(spec=Request)
-        request.body = AsyncMock(return_value=test_body)
-
-        result = await _extract_collection_resource_id_from_post_body(request)
-        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
-
 
 class TestExtractStacResourceId:
     """Tests for extract_stac_resource_id function"""

--- a/common/auth/tests/test_resource_extractors.py
+++ b/common/auth/tests/test_resource_extractors.py
@@ -5,13 +5,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from veda_auth.resource_extractors import (
+    STAC_COLLECTION_PUBLIC,
+    STAC_COLLECTION_TEMPLATE,
+    STAC_ITEM_TEMPLATE,
     _extract_collection_resource_id_from_post_body,
     _extract_tenant_from_body,
     extract_ingest_resource_id,
     extract_stac_resource_id,
 )
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 
 class TestExtractTenantFromBody:
@@ -57,7 +60,7 @@ class TestExtractCollectionResourceIdFromPostBody:
         request.body = AsyncMock(return_value=test_body)
 
         result = await _extract_collection_resource_id_from_post_body(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
     async def test_extract_without_tenant(self):
@@ -69,16 +72,18 @@ class TestExtractCollectionResourceIdFromPostBody:
         request.body = AsyncMock(return_value=test_body)
 
         result = await _extract_collection_resource_id_from_post_body(request)
-        assert result == "stac:collection:public:*"
+        assert result == STAC_COLLECTION_PUBLIC
 
     @pytest.mark.asyncio
     async def test_extract_with_empty_body(self):
-        """Test extracting resource ID with empty body, returns None"""
+        """Test extracting resource ID with empty body raises HTTPException 400"""
         request = MagicMock(spec=Request)
         request.body = AsyncMock(return_value=b"")
 
-        result = await _extract_collection_resource_id_from_post_body(request)
-        assert result is None
+        with pytest.raises(HTTPException) as exc_info:
+            await _extract_collection_resource_id_from_post_body(request)
+        assert exc_info.value.status_code == 400
+        assert "empty body" in exc_info.value.detail.lower()
 
     @pytest.mark.asyncio
     async def test_extract_with_invalid_json(self):
@@ -102,7 +107,7 @@ class TestExtractCollectionResourceIdFromPostBody:
         request.body = AsyncMock(return_value=test_body)
 
         result = await _extract_collection_resource_id_from_post_body(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
 
 class TestExtractStacResourceId:
@@ -117,7 +122,7 @@ class TestExtractStacResourceId:
         request.state.tenant = "test-tenant"
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
     async def test_get_collection_without_tenant(self):
@@ -129,7 +134,7 @@ class TestExtractStacResourceId:
         delattr(request.state, "tenant")
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:collection:public:*"
+        assert result == STAC_COLLECTION_PUBLIC
 
     @pytest.mark.asyncio
     async def test_put_collection_with_tenant_in_body(self):
@@ -143,7 +148,7 @@ class TestExtractStacResourceId:
         request.body = AsyncMock(return_value=test_body)
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
     async def test_get_item_with_tenant(self):
@@ -154,7 +159,7 @@ class TestExtractStacResourceId:
         request.state.tenant = "test-tenant"
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:item:test-tenant:*"
+        assert result == STAC_ITEM_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
     async def test_post_items_with_tenant(self):
@@ -165,7 +170,7 @@ class TestExtractStacResourceId:
         request.state.tenant = "test-tenant"
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
     async def test_post_bulk_items_with_tenant(self):
@@ -176,7 +181,7 @@ class TestExtractStacResourceId:
         request.state.tenant = "test-tenant"
 
         result = await extract_stac_resource_id(request)
-        assert result == "stac:collection:test-tenant:*"
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
 
 class TestExtractIngestResourceId:
@@ -185,7 +190,7 @@ class TestExtractIngestResourceId:
     async def test_delete_collection_returns_collection_id(self):
         """DELETE /collections/{id} should return collection-specific resource ID"""
         request = MagicMock(spec=Request)
-        request.url.path = "/collection/test-collection"
+        request.url.path = "/collections/test-collection"
         request.method = "DELETE"
         request.state.tenant = "test-tenant"
 

--- a/common/auth/tests/test_resource_extractors.py
+++ b/common/auth/tests/test_resource_extractors.py
@@ -7,6 +7,7 @@ import pytest
 from veda_auth.resource_extractors import (
     _extract_collection_resource_id_from_post_body,
     _extract_tenant_from_body,
+    extract_ingest_resource_id,
     extract_stac_resource_id,
 )
 
@@ -176,3 +177,17 @@ class TestExtractStacResourceId:
 
         result = await extract_stac_resource_id(request)
         assert result == "stac:collection:test-tenant:*"
+
+
+class TestExtractIngestResourceId:
+    """Test Ingest API resource ID extraction"""
+
+    async def test_delete_collection_returns_collection_id(self):
+        """DELETE /collections/{id} should return collection-specific resource ID"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collection/test-collection"
+        request.method = "DELETE"
+        request.state.tenant = "test-tenant"
+
+        resource_id = await extract_ingest_resource_id(request)
+        assert resource_id == "collection:test-collection"

--- a/common/auth/tests/test_resource_extractors.py
+++ b/common/auth/tests/test_resource_extractors.py
@@ -1,0 +1,178 @@
+"""Tests for resource extractors"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from veda_auth.resource_extractors import (
+    _extract_collection_resource_id_from_post_body,
+    _extract_tenant_from_body,
+    extract_stac_resource_id,
+)
+
+from fastapi import Request
+
+
+class TestExtractTenantFromBody:
+    """Tests for _extract_tenant_from_body function"""
+
+    def test_extract_tenant(self):
+        """Test extracting tenant from body"""
+        body_data = {"eic:tenant": "test-tenant", "id": "test-collection"}
+        result = _extract_tenant_from_body(body_data)
+        assert result == "test-tenant"
+
+    def test_extract_tenant_custom_field(self):
+        """Test extracting tenant with custom field name"""
+        body_data = {"custom_tenant_field": "test-tenant"}
+        result = _extract_tenant_from_body(
+            body_data, tenant_field="custom_tenant_field"
+        )
+        assert result == "test-tenant"
+
+    def test_no_tenant_in_body(self):
+        """Test when tenant is not present in body"""
+        body_data = {"id": "test-collection", "type": "Collection"}
+        result = _extract_tenant_from_body(body_data)
+        assert result is None
+
+    def test_empty_body(self):
+        """Test with empty body"""
+        body_data = {}
+        result = _extract_tenant_from_body(body_data)
+        assert result is None
+
+
+class TestExtractCollectionResourceIdFromPostBody:
+    """Tests for _extract_collection_resource_id_from_post_body function"""
+
+    @pytest.mark.asyncio
+    async def test_extract_with_tenant(self):
+        """Test extracting resource ID when tenant is present in body"""
+        body_data = {"eic:tenant": "test-tenant", "id": "test-collection"}
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await _extract_collection_resource_id_from_post_body(request)
+        assert result == "stac:collection:test-tenant:*"
+
+    @pytest.mark.asyncio
+    async def test_extract_without_tenant(self):
+        """Test extracting resource ID when tenant is not present (defaults to public)."""
+        body_data = {"id": "test-collection", "type": "Collection"}
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await _extract_collection_resource_id_from_post_body(request)
+        assert result == "stac:collection:public:*"
+
+    @pytest.mark.asyncio
+    async def test_extract_with_empty_body(self):
+        """Test extracting resource ID with empty body, returns None"""
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=b"")
+
+        result = await _extract_collection_resource_id_from_post_body(request)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_with_invalid_json(self):
+        """Test extracting resource ID with invalid JSON, also returns None"""
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=b"invalid json")
+
+        result = await _extract_collection_resource_id_from_post_body(request)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_extract_tenant_from_properties(self):
+        """Test extracting resource ID when tenant is in properties"""
+        body_data = {
+            "id": "test-collection",
+            "properties": {"eic:tenant": "test-tenant"},
+        }
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await _extract_collection_resource_id_from_post_body(request)
+        assert result == "stac:collection:test-tenant:*"
+
+
+class TestExtractStacResourceId:
+    """Tests for extract_stac_resource_id function"""
+
+    @pytest.mark.asyncio
+    async def test_get_collection_with_tenant(self):
+        """Test extracting resource ID for GET collection with tenant"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection"
+        request.method = "GET"
+        request.state.tenant = "test-tenant"
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:collection:test-tenant:*"
+
+    @pytest.mark.asyncio
+    async def test_get_collection_without_tenant(self):
+        """Test extracting resource ID for GET collection without tenant (defaults to public)"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection"
+        request.method = "GET"
+        request.state = MagicMock()
+        delattr(request.state, "tenant")
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:collection:public:*"
+
+    @pytest.mark.asyncio
+    async def test_put_collection_with_tenant_in_body(self):
+        """Test extracting resource ID for PUT collection with tenant in body"""
+        body_data = {"eic:tenant": "test-tenant", "id": "test-collection"}
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection"
+        request.method = "PUT"
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:collection:test-tenant:*"
+
+    @pytest.mark.asyncio
+    async def test_get_item_with_tenant(self):
+        """Test extracting resource ID for GET item with tenant"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection/items/test-item"
+        request.method = "GET"
+        request.state.tenant = "test-tenant"
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:item:test-tenant:*"
+
+    @pytest.mark.asyncio
+    async def test_post_items_with_tenant(self):
+        """Test extracting resource ID for POST items with tenant"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection/items"
+        request.method = "POST"
+        request.state.tenant = "test-tenant"
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:collection:test-tenant:*"
+
+    @pytest.mark.asyncio
+    async def test_post_bulk_items_with_tenant(self):
+        """Test extracting resource ID for POST bulk_items with tenant"""
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections/test-collection/bulk_items"
+        request.method = "POST"
+        request.state.tenant = "test-tenant"
+
+        result = await extract_stac_resource_id(request)
+        assert result == "stac:collection:test-tenant:*"

--- a/common/auth/tests/test_resource_extractors.py
+++ b/common/auth/tests/test_resource_extractors.py
@@ -136,6 +136,34 @@ class TestExtractStacResourceId:
         assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
 
     @pytest.mark.asyncio
+    async def test_post_collections_create_with_tenant_in_body(self):
+        """Test extracting resource ID for STAC POST /collections (create, from transactions enabled) with tenant in body"""
+        body_data = {"eic:tenant": "test-tenant", "id": "new-collection"}
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections"
+        request.method = "POST"
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await extract_stac_resource_id(request)
+        assert result == STAC_COLLECTION_TEMPLATE.format("test-tenant")
+
+    @pytest.mark.asyncio
+    async def test_post_collections_create_without_tenant_in_body(self):
+        """Test extracting resource ID for STAC POST /collections (create, from transactions enabled) without tenant (defaults to public)"""
+        body_data = {"id": "new-collection", "type": "Collection"}
+        test_body = json.dumps(body_data).encode("utf-8")
+
+        request = MagicMock(spec=Request)
+        request.url.path = "/collections"
+        request.method = "POST"
+        request.body = AsyncMock(return_value=test_body)
+
+        result = await extract_stac_resource_id(request)
+        assert result == STAC_COLLECTION_PUBLIC
+
+    @pytest.mark.asyncio
     async def test_get_item_with_tenant(self):
         """Test extracting resource ID for GET item with tenant"""
         request = MagicMock(spec=Request)

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -110,3 +110,19 @@ async def extract_stac_resource_id(request: Request) -> Optional[str]:
         return None
 
     return None
+
+
+async def extract_ingest_resource_id(request: Request) -> Optional[str]:
+    """Extract resource ID for Ingest API requests"""
+    path = request.url.path
+    method = request.method
+
+    if path.endswith("/collections") and method == "POST":
+        return await _extract_collection_resource_id_from_post_body(request)
+
+    match = re.match(r".*?/collections/([^/]+)$", path)
+    if match and method == "DELETE":
+        collection_id = match.group(1)
+        return f"collection:{collection_id}"
+
+    return None

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -22,6 +22,25 @@ STAC_ITEM_PUBLIC = "stac:item:public:*"
 STAC_COLLECTION_TEMPLATE = "stac:collection:{}:*"
 STAC_ITEM_TEMPLATE = "stac:item:{}:*"
 
+_COLLECTIONS_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)$")
+_COLLECTIONS_ITEM_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)/items/([^/]+)$")
+_COLLECTIONS_ITEMS_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)/items$")
+_COLLECTIONS_BULK_ITEMS_PATH_PATTERN = re.compile(
+    r".*?/collections/([^/]+)/bulk_items$"
+)
+
+
+def _stac_collection_resource_id(request: Request) -> str:
+    """Return tenant-based or public STAC collection resource ID."""
+    tenant = getattr(request.state, "tenant", None)
+    return STAC_COLLECTION_TEMPLATE.format(tenant) if tenant else STAC_COLLECTION_PUBLIC
+
+
+def _stac_item_resource_id(request: Request) -> str:
+    """Return tenant-based or public STAC item resource ID."""
+    tenant = getattr(request.state, "tenant", None)
+    return STAC_ITEM_TEMPLATE.format(tenant) if tenant else STAC_ITEM_PUBLIC
+
 
 def _extract_tenant_from_body(
     body_data: Dict[str, Any], tenant_field: Optional[str] = None
@@ -78,36 +97,18 @@ async def extract_stac_resource_id(request: Request) -> Optional[str]:
     path = request.url.path
     method = request.method
 
-    match = re.match(r".*?/collections/([^/]+)$", path)
-    if match:
+    if _COLLECTIONS_PATH_PATTERN.match(path):
         if method in ("PUT", "PATCH"):
             return await _extract_collection_resource_id_from_post_body(request)
+        return _stac_collection_resource_id(request)
 
-        tenant = getattr(request.state, "tenant", None)
-        if tenant:
-            return STAC_COLLECTION_TEMPLATE.format(tenant)
-        return STAC_COLLECTION_PUBLIC
+    if _COLLECTIONS_ITEM_PATH_PATTERN.match(path):
+        return _stac_item_resource_id(request)
 
-    match = re.match(r".*?/collections/([^/]+)/items/([^/]+)$", path)
-    if match:
-        tenant = getattr(request.state, "tenant", None)
-        if tenant:
-            return STAC_ITEM_TEMPLATE.format(tenant)
-        return STAC_ITEM_PUBLIC
-
-    match = re.match(r".*?/collections/([^/]+)/items$", path)
-    if match:
-        tenant = getattr(request.state, "tenant", None)
-        if tenant:
-            return STAC_COLLECTION_TEMPLATE.format(tenant)
-        return STAC_COLLECTION_PUBLIC
-
-    match = re.match(r".*?/collections/([^/]+)/bulk_items$", path)
-    if match:
-        tenant = getattr(request.state, "tenant", None)
-        if tenant:
-            return STAC_COLLECTION_TEMPLATE.format(tenant)
-        return STAC_COLLECTION_PUBLIC
+    if _COLLECTIONS_ITEMS_PATH_PATTERN.match(
+        path
+    ) or _COLLECTIONS_BULK_ITEMS_PATH_PATTERN.match(path):
+        return _stac_collection_resource_id(request)
 
     if "/queryables" in path or "/search" in path:
         return None

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -12,11 +12,15 @@ import os
 import re
 from typing import Any, Dict, Optional
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 logger = logging.getLogger(__name__)
 
 TENANT_FIELD = os.getenv("VEDA_TENANT_FILTER_FIELD", "eic:tenant")
+STAC_COLLECTION_PUBLIC = "stac:collection:public:*"
+STAC_ITEM_PUBLIC = "stac:item:public:*"
+STAC_COLLECTION_TEMPLATE = "stac:collection:{}:*"
+STAC_ITEM_TEMPLATE = "stac:item:{}:*"
 
 
 def _extract_tenant_from_body(
@@ -50,17 +54,16 @@ async def _extract_collection_resource_id_from_post_body(
     try:
         request_body = await request.body()
         if not request_body:
-            logger.warning(
-                "Cannot extract resource ID: empty body for collection operation"
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot extract resource ID: empty body for collection operation",
             )
-            return None
 
         body_data = json.loads(request_body)
         tenant = _extract_tenant_from_body(body_data)
         if tenant:
-            return f"stac:collection:{tenant}:*"
-        else:
-            return "stac:collection:public:*"
+            return STAC_COLLECTION_TEMPLATE.format(tenant)
+        return STAC_COLLECTION_PUBLIC
     except (json.JSONDecodeError, AttributeError, TypeError) as e:
         logger.warning(f"Failed to extract resource ID from collection body: {e}")
         return None
@@ -69,8 +72,8 @@ async def _extract_collection_resource_id_from_post_body(
 async def extract_stac_resource_id(request: Request) -> Optional[str]:
     """Extract resource ID for STAC API requests
     Resource ID format matches Keycloak resource definitions (wildcard patterns):
-    - Collections: "stac:collection:{tenant}:*" or "stac:collection:public:*"
-    - Items: "stac:item:{tenant}:*" or "stac:item:public:*"
+    - Collections: STAC_COLLECTION_TEMPLATE or STAC_COLLECTION_PUBLIC
+    - Items: STAC_ITEM_TEMPLATE or STAC_ITEM_PUBLIC
     """
     path = request.url.path
     method = request.method
@@ -82,29 +85,29 @@ async def extract_stac_resource_id(request: Request) -> Optional[str]:
 
         tenant = getattr(request.state, "tenant", None)
         if tenant:
-            return f"stac:collection:{tenant}:*"
-        return "stac:collection:public:*"
+            return STAC_COLLECTION_TEMPLATE.format(tenant)
+        return STAC_COLLECTION_PUBLIC
 
     match = re.match(r".*?/collections/([^/]+)/items/([^/]+)$", path)
     if match:
         tenant = getattr(request.state, "tenant", None)
         if tenant:
-            return f"stac:item:{tenant}:*"
-        return "stac:item:public:*"
+            return STAC_ITEM_TEMPLATE.format(tenant)
+        return STAC_ITEM_PUBLIC
 
     match = re.match(r".*?/collections/([^/]+)/items$", path)
     if match:
         tenant = getattr(request.state, "tenant", None)
         if tenant:
-            return f"stac:collection:{tenant}:*"
-        return "stac:collection:public:*"
+            return STAC_COLLECTION_TEMPLATE.format(tenant)
+        return STAC_COLLECTION_PUBLIC
 
     match = re.match(r".*?/collections/([^/]+)/bulk_items$", path)
     if match:
         tenant = getattr(request.state, "tenant", None)
         if tenant:
-            return f"stac:collection:{tenant}:*"
-        return "stac:collection:public:*"
+            return STAC_COLLECTION_TEMPLATE.format(tenant)
+        return STAC_COLLECTION_PUBLIC
 
     if "/queryables" in path or "/search" in path:
         return None

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -22,6 +22,7 @@ STAC_ITEM_PUBLIC = "stac:item:public:*"
 STAC_COLLECTION_TEMPLATE = "stac:collection:{}:*"
 STAC_ITEM_TEMPLATE = "stac:item:{}:*"
 
+_COLLECTIONS_CREATE_PATH_PATTERN = re.compile(r".*?/collections$")
 _COLLECTIONS_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)$")
 _COLLECTIONS_ITEM_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)/items/([^/]+)$")
 _COLLECTIONS_ITEMS_PATH_PATTERN = re.compile(r".*?/collections/([^/]+)/items$")
@@ -90,6 +91,9 @@ async def extract_stac_resource_id(request: Request) -> Optional[str]:
     """
     path = request.url.path
     method = request.method
+
+    if _COLLECTIONS_CREATE_PATH_PATTERN.match(path) and method == "POST":
+        return await _extract_collection_resource_id_from_post_body(request)
 
     if _COLLECTIONS_PATH_PATTERN.match(path):
         if method in ("PUT", "PATCH"):

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -54,12 +54,6 @@ def _extract_tenant_from_body(
         if tenant:
             return tenant
 
-        properties = body_data.get("properties", {})
-        if isinstance(properties, dict):
-            tenant = properties.get(tenant_field)
-            if tenant:
-                return tenant
-
         return None
     except (AttributeError, TypeError) as e:
         logger.debug(f"Failed to extract tenant from body: {e}")

--- a/common/auth/veda_auth/resource_extractors.py
+++ b/common/auth/veda_auth/resource_extractors.py
@@ -1,0 +1,112 @@
+"""" Resource Extractors to use in PEP Middleware.
+We need to extract the following from a request in order to create a permission ticket request:
+- resource id
+- scope
+- tenant
+https://www.keycloak.org/docs/latest/authorization_services/index.html#creating-permission-ticket
+"""
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, Optional
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+TENANT_FIELD = os.getenv("VEDA_TENANT_FILTER_FIELD", "eic:tenant")
+
+
+def _extract_tenant_from_body(
+    body_data: Dict[str, Any], tenant_field: Optional[str] = None
+) -> Optional[str]:
+    """Extract tenant from request body JSON data"""
+    if tenant_field is None:
+        tenant_field = TENANT_FIELD
+
+    try:
+        tenant = body_data.get(tenant_field)
+        if tenant:
+            return tenant
+
+        properties = body_data.get("properties", {})
+        if isinstance(properties, dict):
+            tenant = properties.get(tenant_field)
+            if tenant:
+                return tenant
+
+        return None
+    except (AttributeError, TypeError) as e:
+        logger.debug(f"Failed to extract tenant from body: {e}")
+        return None
+
+
+async def _extract_collection_resource_id_from_post_body(
+    request: Request,
+) -> Optional[str]:
+    """Extract collection resource ID from POST/PUT collections request body"""
+    try:
+        request_body = await request.body()
+        if not request_body:
+            logger.warning(
+                "Cannot extract resource ID: empty body for collection operation"
+            )
+            return None
+
+        body_data = json.loads(request_body)
+        tenant = _extract_tenant_from_body(body_data)
+        if tenant:
+            return f"stac:collection:{tenant}:*"
+        else:
+            return "stac:collection:public:*"
+    except (json.JSONDecodeError, AttributeError, TypeError) as e:
+        logger.warning(f"Failed to extract resource ID from collection body: {e}")
+        return None
+
+
+async def extract_stac_resource_id(request: Request) -> Optional[str]:
+    """Extract resource ID for STAC API requests
+    Resource ID format matches Keycloak resource definitions (wildcard patterns):
+    - Collections: "stac:collection:{tenant}:*" or "stac:collection:public:*"
+    - Items: "stac:item:{tenant}:*" or "stac:item:public:*"
+    """
+    path = request.url.path
+    method = request.method
+
+    match = re.match(r".*?/collections/([^/]+)$", path)
+    if match:
+        if method in ("PUT", "PATCH"):
+            return await _extract_collection_resource_id_from_post_body(request)
+
+        tenant = getattr(request.state, "tenant", None)
+        if tenant:
+            return f"stac:collection:{tenant}:*"
+        return "stac:collection:public:*"
+
+    match = re.match(r".*?/collections/([^/]+)/items/([^/]+)$", path)
+    if match:
+        tenant = getattr(request.state, "tenant", None)
+        if tenant:
+            return f"stac:item:{tenant}:*"
+        return "stac:item:public:*"
+
+    match = re.match(r".*?/collections/([^/]+)/items$", path)
+    if match:
+        tenant = getattr(request.state, "tenant", None)
+        if tenant:
+            return f"stac:collection:{tenant}:*"
+        return "stac:collection:public:*"
+
+    match = re.match(r".*?/collections/([^/]+)/bulk_items$", path)
+    if match:
+        tenant = getattr(request.state, "tenant", None)
+        if tenant:
+            return f"stac:collection:{tenant}:*"
+        return "stac:collection:public:*"
+
+    if "/queryables" in path or "/search" in path:
+        return None
+
+    return None


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/556

### What?/Why?

This PR  adds resource extractor functions that parse HTTP requests to extract resource ids and scopes that are needed for Keycloak's RPT endpoint.

In order to create a permission ticket or request an RPT from keycloak, we need
- resource id (needs to follow convention defined in our [keycloak config ](https://github.com/NASA-IMPACT/veda-keycloak/blob/main/keycloak-config-cli/config/dev/veda.yaml#L334))
- scope (action being performed)

Additional Context, from https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_obtaining_permissions
```
Example of an authorization request when a client is seeking access to two resources protected by a resource server.

curl -X POST \
  http://${host}:${port}/realms/${realm-name}/protocol/openid-connect/token \
  -H "Authorization: Bearer ${access_token}" \
  --data "grant_type=urn:ietf:params:oauth:grant-type:uma-ticket" \
  --data "audience={resource_server_client_id}" \
  --data "permission=Resource A#Scope A" \
  --data "permission=Resource B#Scope B"
```

### Testing?

- Unit tests
- I will add integration tests when we create the actual policy enforcement point middleware that will use these functions 

You can also test this yourself trying different permission permutations. A successful request looks like:
```
curl -X POST \
  https://[HOST]/realms/veda/protocol/openid-connect/token \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -d 'grant_type=urn:ietf:params:oauth:grant-type:uma-ticket' \
  -d 'audience=uma-resource-server' \
  -d 'client_id=uma-resource-server' \
  -d 'client_secret=[redacted]' \
  -d 'permission=stac:collection:faketenant1:*#create' \
  -H "Authorization: Bearer TOKEN"
{"upgraded":false,"access_token":"redacted","token_type":"Bearer","not-before-policy":0}%
```

And one where you are not authorized because you either aren't in a Tenancy group or don't have sufficient permissions (determined by your role) in a tenancy, will yield

```
{"error":"access_denied","error_description":"not_authorized"}%                   
```