### PR TITLE
fix: pin titiler and mangum

### DIFF
--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -5,7 +5,7 @@ RUN dnf install -y gcc-c++
 WORKDIR /tmp
 
 COPY raster_api/runtime /tmp/raster
-RUN pip install mangum /tmp/raster["psycopg-binary"] -t /asset --no-binary pydantic
+RUN pip install "mangum<=0.19" /tmp/raster["psycopg-binary"] -t /asset --no-binary pydantic
 RUN rm -rf /tmp/raster
 RUN cp /usr/lib64/libexpat.so.1 /asset/
 

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -11,9 +11,9 @@ inst_reqs = [
     "rio-tiler>=7.0,<8.0",
     "titiler.pgstac==1.5.0",
     # use highest available titiler based on rio-tiler and titiler-pgstac pins (not 2.0 yet though)
-    "titiler.core<0.20,<2.0",
-    "titiler.mosaic<2.0",
-    "titiler.extensions[cogeo]<2.0",
+    "titiler.core<0.20",
+    "titiler.mosaic<0.20",
+    "titiler.extensions[cogeo]<0.20",
     "starlette-cramjam>=0.3,<0.4",
     # based on AWS observability requirements
     "aws_xray_sdk>=2.6.0,<3",

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -10,15 +10,16 @@ inst_reqs = [
     # highest-tested versions of raster_api dependencies
     "rio-tiler>=7.0,<8.0",
     "titiler.pgstac==1.5.0",
-    # use highest available titiler based on rio-tiler and titiler-pgstac pins
-    "titiler.core<0.20",
-    "titiler.mosaic",
-    "titiler.extensions[cogeo]",
+    # use highest available titiler based on rio-tiler and titiler-pgstac pins (not 2.0 yet though)
+    "titiler.core<0.20,<2.0",
+    "titiler.mosaic<2.0",
+    "titiler.extensions[cogeo]<2.0",
     "starlette-cramjam>=0.3,<0.4",
     # based on AWS observability requirements
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
     "python-multipart==0.0.7",
+    "mangum<=0.19",
 ]
 
 extra_reqs = {

--- a/raster_api/runtime/setup.py
+++ b/raster_api/runtime/setup.py
@@ -19,7 +19,6 @@ inst_reqs = [
     "aws_xray_sdk>=2.6.0,<3",
     "aws-lambda-powertools>=1.18.0",
     "python-multipart==0.0.7",
-    "mangum<=0.19",
 ]
 
 extra_reqs = {

--- a/stac_api/runtime/Dockerfile
+++ b/stac_api/runtime/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /tmp
 COPY common/auth /tmp/common_auth
 COPY stac_api/runtime /tmp/stac
 
-RUN pip install "mangum" "plpygis>=0.2.1" /tmp/common_auth /tmp/stac -t /asset --no-binary pydantic
+RUN pip install "mangum<=0.19" "plpygis>=0.2.1" /tmp/common_auth /tmp/stac -t /asset --no-binary pydantic
 RUN rm -rf /tmp/stac
 
 # Reduce package size and remove useless files

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -223,8 +223,9 @@ async def viewer_page(request: Request):
     """Search viewer."""
     path = api_settings.root_path or ""
     return templates.TemplateResponse(
+        request,
         "stac-viewer.html",
-        {"request": request, "endpoint": str(request.url).replace("/index.html", path)},
+        {"endpoint": str(request.url).replace("/index.html", path)},
         media_type="text/html",
     )
 


### PR DESCRIPTION
### Issue

No issue - related [thread in Slack](https://developmentseed.slack.com/archives/C045K5LAFA9/p1774368650506379)

### What?

- Pin dependencies so we don't use `titiler>=2.0` or `mangum>0.19` for the raster API

### Testing?

- Tests pass locally