### PR TITLE
feat: add tiler url override feat to search

### DIFF
--- a/stac_api/runtime/src/core.py
+++ b/stac_api/runtime/src/core.py
@@ -1,6 +1,6 @@
 """CoreCrudClient extensions for the VEDA STAC API."""
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 from stac_fastapi.pgstac.core import CoreCrudClient
 from stac_fastapi.pgstac.types.search import PgstacSearch
@@ -21,15 +21,14 @@ class VedaCrudClient(CoreCrudClient):
         render_key: str,
         render_params: Dict[str, Any],
         request: Request,
-        tiler_override: Optional[str] = None,
     ) -> Item:
         """Add extra/non-mandatory links to an Item"""
         collection_id = item.get("collection", "")
 
         if collection_id:
-            LinkInjector(
-                collection_id, render_key, render_params, request, tiler_override
-            ).inject_item(item)
+            LinkInjector(collection_id, render_key, render_params, request).inject_item(
+                item
+            )
 
         return item
 
@@ -59,15 +58,12 @@ class VedaCrudClient(CoreCrudClient):
 
                 render_params = collection.get("renders", {})
                 if len(render_params):
-                    tiler_override = render_params.get("tiler_url")
                     for key, value in render_params.items():
                         item_collection = ItemCollection(
                             **{
                                 **result,
                                 "features": [
-                                    self.inject_item_links(
-                                        i, key, value, request, tiler_override
-                                    )
+                                    self.inject_item_links(i, key, value, request)
                                     for i in result.get("features", [])
                                 ],
                             }

--- a/stac_api/runtime/src/core.py
+++ b/stac_api/runtime/src/core.py
@@ -1,6 +1,6 @@
 """CoreCrudClient extensions for the VEDA STAC API."""
 
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from stac_fastapi.pgstac.core import CoreCrudClient
 from stac_fastapi.pgstac.types.search import PgstacSearch
@@ -21,14 +21,15 @@ class VedaCrudClient(CoreCrudClient):
         render_key: str,
         render_params: Dict[str, Any],
         request: Request,
+        tiler_override: Optional[str] = None,
     ) -> Item:
         """Add extra/non-mandatory links to an Item"""
         collection_id = item.get("collection", "")
 
         if collection_id:
-            LinkInjector(collection_id, render_key, render_params, request).inject_item(
-                item
-            )
+            LinkInjector(
+                collection_id, render_key, render_params, request, tiler_override
+            ).inject_item(item)
 
         return item
 
@@ -58,12 +59,15 @@ class VedaCrudClient(CoreCrudClient):
 
                 render_params = collection.get("renders", {})
                 if len(render_params):
+                    tiler_override = render_params.get("tiler_url")
                     for key, value in render_params.items():
                         item_collection = ItemCollection(
                             **{
                                 **result,
                                 "features": [
-                                    self.inject_item_links(i, key, value, request)
+                                    self.inject_item_links(
+                                        i, key, value, request, tiler_override
+                                    )
                                     for i in result.get("features", [])
                                 ],
                             }

--- a/stac_api/runtime/src/links.py
+++ b/stac_api/runtime/src/links.py
@@ -1,6 +1,6 @@
 """A module for injecting links to STAC entries"""
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 from urllib.parse import urljoin
 
 import pystac
@@ -34,7 +34,6 @@ class LinkInjector:
         render_key: str,
         render_params: Dict[str, Any],
         request: Request,
-        tiler_override: Optional[str] = None,
     ) -> None:
         """Initialize a LinkInjector"""
 
@@ -43,7 +42,9 @@ class LinkInjector:
         self.collection_id = collection_id
         self.render_key = render_key
         self.render_config = get_render_config(render_params)
-        self.tiler_href = tiler_override or tiles_settings.titiler_endpoint or ""
+        self.tiler_href = (
+            render_params.get("tiler_url") or tiles_settings.titiler_endpoint or ""
+        )
 
     def inject_item(self, item: Item) -> None:
         """Inject rendering links to an item"""

--- a/stac_api/runtime/src/links.py
+++ b/stac_api/runtime/src/links.py
@@ -1,6 +1,6 @@
 """A module for injecting links to STAC entries"""
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 
 import pystac
@@ -34,6 +34,7 @@ class LinkInjector:
         render_key: str,
         render_params: Dict[str, Any],
         request: Request,
+        tiler_override: Optional[str] = None,
     ) -> None:
         """Initialize a LinkInjector"""
 
@@ -42,7 +43,7 @@ class LinkInjector:
         self.collection_id = collection_id
         self.render_key = render_key
         self.render_config = get_render_config(render_params)
-        self.tiler_href = tiles_settings.titiler_endpoint or ""
+        self.tiler_href = tiler_override or tiles_settings.titiler_endpoint or ""
 
     def inject_item(self, item: Item) -> None:
         """Inject rendering links to an item"""

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -512,3 +512,19 @@ def valid_stac_collection_multi_cog_asset_renders_with_dashboard(
     coll = copy.deepcopy(valid_stac_collection_multi_cog_asset_renders)
     coll["renders"]["dashboard"] = {"nodata": -9999, "assets": ["burnRatio"]}
     return coll
+
+
+@pytest.fixture
+def valid_stac_collection_renders_with_tiler_url(
+    valid_stac_collection_multi_cog_asset_renders,
+):
+    """
+    Fixture providing a valid STAC feature collection with renders configuration
+    that includes an optional 'tiler_url' override attribute.
+
+    Returns:
+        dict: A valid STAC collection with renders configuration including tiler_url.
+    """
+    coll = copy.deepcopy(valid_stac_collection_multi_cog_asset_renders)
+    coll["renders"]["tiler_url"] = "https://custom-tiler.example.com"
+    return coll

--- a/stac_api/runtime/tests/conftest.py
+++ b/stac_api/runtime/tests/conftest.py
@@ -526,5 +526,6 @@ def valid_stac_collection_renders_with_tiler_url(
         dict: A valid STAC collection with renders configuration including tiler_url.
     """
     coll = copy.deepcopy(valid_stac_collection_multi_cog_asset_renders)
-    coll["renders"]["tiler_url"] = "https://custom-tiler.example.com"
+    for render_config in coll["renders"].values():
+        render_config["tiler_url"] = "https://custom-tiler.example.com"
     return coll

--- a/stac_api/runtime/tests/test_core.py
+++ b/stac_api/runtime/tests/test_core.py
@@ -154,3 +154,49 @@ class TestSearchBase:
         ]
         # Check that all expected render previews are generated for all assets in render config
         assert assets_keys == expected_render_assets
+
+    async def test_tiler_url_override_in_renders(
+        self, valid_stac_collection_renders_with_tiler_url
+    ):
+        """When 'tiler_url' is present in renders config, uses instead of the default titiler_endpoint."""
+        client = self.client
+        search_request = self.search_request
+        request = self.request
+
+        custom_tiler_url = "https://custom-tiler.example.com"
+        default_tiler_url = "https://default-titiler.example.com"
+
+        with patch.object(
+            CoreCrudClient, "_search_base", new_callable=AsyncMock
+        ) as mock_super_search, patch.object(
+            CoreCrudClient, "get_collection", new_callable=AsyncMock
+        ) as mock_get_collection, patch(
+            "src.links.tiles_settings.titiler_endpoint",
+            new=default_tiler_url,
+        ):
+            mock_super_search.return_value = (
+                valid_stac_collection_renders_with_tiler_url
+            )
+            mock_get_collection.return_value = (
+                valid_stac_collection_renders_with_tiler_url
+            )
+
+            returned = await client._search_base(search_request, request=request)
+
+        assert "features" in returned
+        feature = returned["features"][0]
+
+        links = feature["links"]
+        assets = feature["assets"]
+
+        # All generated hrefs should use the custom tiler_url, not the default endpoint
+        for link in links:
+            assert link["href"].startswith(
+                custom_tiler_url
+            ), f"Expected link href to use tiler_url ({custom_tiler_url}), got: {link['href']}"
+
+        rendered_preview_keys = [k for k in assets if k.startswith("rendered_preview_")]
+        for key in rendered_preview_keys:
+            assert assets[key]["href"].startswith(
+                custom_tiler_url
+            ), f"Expected preview href to use tiler_url ({custom_tiler_url}), got: {assets[key]['href']}"


### PR DESCRIPTION
Related ticket: https://github.com/NASA-IMPACT/veda-backend/issues/579

**About Changes:**
an optional `tiler_url` can be passed into the renders configuration at the attribute level to override the default titiler url

For example:
```
...
"renders": {
    "ndvi": {
      "tiler_url": "somecustomertilerhref",
      "assets": [
        "ndvi"
      ],
      "nodata": 0,
      "rescale": [
        [-1, 1]
      ]
    },
```