### PR TITLE
refactor: remove ingest_api/items and ItemPublisher class

### DIFF
--- a/ingest_api/runtime/src/collection_publisher.py
+++ b/ingest_api/runtime/src/collection_publisher.py
@@ -4,7 +4,6 @@ from pypgstac.db import PgstacDB
 from src.schemas import DashboardCollection
 from src.utils import IngestionType, get_db_credentials, load_into_pgstac
 from src.vedaloader import VEDALoader
-from stac_pydantic import Item
 
 
 class CollectionPublisher:
@@ -29,16 +28,3 @@ class CollectionPublisher:
         with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
             loader = VEDALoader(db=db)
             loader.delete_collection(collection_id)
-
-
-class ItemPublisher:
-    def ingest(self, item: Item):
-        """
-        Takes an item model,
-        does necessary preprocessing,
-        and loads into the PgSTAC item table
-        """
-        creds = get_db_credentials(os.environ["DB_SECRET_ARN"])
-        item = [item.to_dict()]
-        with PgstacDB(dsn=creds.dsn_string, debug=True) as db:
-            load_into_pgstac(db=db, ingestions=item, table=IngestionType.items)

--- a/ingest_api/runtime/src/main.py
+++ b/ingest_api/runtime/src/main.py
@@ -3,7 +3,7 @@ import src.schemas as schemas
 import src.services as services
 from aws_lambda_powertools.metrics import MetricUnit
 from src.auth import auth_settings, get_username, oidc_auth
-from src.collection_publisher import CollectionPublisher, ItemPublisher
+from src.collection_publisher import CollectionPublisher
 from src.config import settings
 from src.doc import DESCRIPTION
 from src.monitoring import ObservabilityMiddleware, logger, metrics, tracer
@@ -33,7 +33,6 @@ app = FastAPI(
 )
 
 collection_publisher = CollectionPublisher()
-item_publisher = ItemPublisher()
 
 
 @app.get(
@@ -182,29 +181,6 @@ def delete_collection(collection_id: str):
     except Exception as e:
         print(e)
         raise HTTPException(status_code=400, detail=(f"{e}"))
-
-
-@app.post(
-    "/items",
-    tags=["Items"],
-    status_code=201,
-    dependencies=[
-        Security(oidc_auth.valid_token_dependency, scopes="stac:item:create")
-    ],
-)
-def publish_item(item: schemas.Item):
-    """
-    Publish an item to the STAC database.
-    """
-    # pgstac create item
-    try:
-        item_publisher.ingest(item)
-        return {f"Successfully published: {item.id}"}
-    except Exception as e:
-        raise HTTPException(
-            status_code=400,
-            detail=(f"Unable to publish item: {e}"),
-        )
 
 
 @app.get("/auth/me", tags=["Auth"])

--- a/stac_api/runtime/src/app.py
+++ b/stac_api/runtime/src/app.py
@@ -136,8 +136,9 @@ async def viewer_page(request: Request):
     """Search viewer."""
     path = api_settings.root_path or ""
     return templates.TemplateResponse(
-        "stac-viewer.html",
-        {"request": request, "endpoint": str(request.url).replace("/index.html", path)},
+        request=request,
+        name="stac-viewer.html",
+        context={"endpoint": str(request.url).replace("/index.html", path)},
         media_type="text/html",
     )
 


### PR DESCRIPTION
### Issue

closes #568 

### What?

remove `ingest_api/items` api route from `ingest_api/runtime/src/main.py`  and ItemPublisher class from `ingest_api/runtime/src/collection_publisher.py`

### Why?

Remove the items endpoint from the ingest API because it is unmaintained and duplicates functionality better covered in the stac-api. Users now have the option to use stac-api transactions for item operations.


