### PR TITLE
fix(stac-api): root path bug and docs update

### DIFF
--- a/stac_api/runtime/README.md
+++ b/stac_api/runtime/README.md
@@ -4,7 +4,7 @@
 
 Tenant-related behavior comes from **several middleware components**. Each row names one component, what it does, and how it is turned on (some are always on; others depend on environment variables).
 
-| Component | Role | Enabled when: |
+| Component | Role | Enabled when |
 | --- | --- | --- |
 | **`TenantExtractionMiddleware`** | Parses tenant URLs such as `{root_path}/{tenant}/collections`, sets `request.state.tenant`, and rewrites `scope["path"]` so routing matches the usual STAC paths. | **Always** (see `app.py`). Independent of `VEDA_STAC_ENABLE_STAC_AUTH_PROXY`. |
 | **`TenantLinksMiddleware`** | For JSON STAC responses, rewrites `links` so clients stay on the tenant-prefixed URL when a tenant is present. | **Always** (see `app.py`). |
@@ -13,7 +13,7 @@ Tenant-related behavior comes from **several middleware components**. Each row n
 
 **How this fits together:**
 
-- **Tenant in the URL** (`/api/stac/veda/collections`, …) is handled by the **two URL-tenant middleware components** in the table so the core STAC app still sees `/api/stac/collections` while `request.state.tenant` is set. That works even when the auth proxy wrapper is **off**.
+- **Tenant in the URL** (`/api/stac/{Tenant=veda}/collections`, …) is handled by the **two URL-tenant middleware components** in the table so the core STAC app still sees `/api/stac/collections` while `request.state.tenant` is set. That works even when the auth proxy wrapper is **off**.
 - **Tenant in collection metadata** (filtering which collections/items appear for a tenant) is driven by the **filters registered through `stac-auth-proxy`** when the proxy is **on**. Turning the proxy off removes that integration; it does **not** remove URL parsing or link rewriting from the tenant middleware.
 - **Transactions** still require `VEDA_STAC_ENABLE_TRANSACTIONS=True` and, per configuration rules, `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` when transactions are enabled.
 
@@ -60,12 +60,12 @@ The `eic:tenant` field should contain a string identifier for the tenant.
 
 Multi-tenancy has several parts. The **two optional layers** below (auth-proxy filter integration and PEP) are toggled independently. Both require `VEDA_STAC_OPENID_CONFIGURATION_URL` to be set, plus each layer’s own second flag.
 
-| Layer | What it does | Enabled when |
-| --- | --- | --- |
-| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`: OpenID Connect, registers `CollectionFilter` / `ItemFilter` for tenant-aware list/search, OAuth-scoped write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` |
-| **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set |
+| Layer | What it does | Enabled when | Disabled when |
+| --- | --- | --- | --- |
+| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`: OpenID Connect, registers `CollectionFilter` / `ItemFilter` for tenant-aware list/search, OAuth-scoped write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` | `VEDA_STAC_OPENID_CONFIGURATION_URL` is not set **or** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=False` |
+| **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set | `VEDA_STAC_OPENID_CONFIGURATION_URL` is not set **or** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is not set |
 
-> **_NOTE:_**  `TenantExtractionMiddleware` and `TenantLinksMiddleware` (URL tenant prefix and JSON link rewriting) are **always** registered. They do not appear in this table because they are not toggled by these env vars; see [Middleware and multitenancy](#middleware-and-multitenancy). When clients only use normal STAC paths (for example `/api/stac/collections` with no extra path segment), tenant extraction is a no-op.
+> **_NOTE:_**  `TenantExtractionMiddleware` and `TenantLinksMiddleware` (URL tenant prefix and JSON link rewriting) are **always** registered. They do not appear in this table because they are not toggled by these env vars; see [Middleware and multitenancy components](#middleware-and-multitenancy-components). When clients only use normal STAC paths (for example `/api/stac/collections` with no extra path segment), tenant extraction is a no-op.
 
 ### Turning off each layer individually
 

--- a/stac_api/runtime/README.md
+++ b/stac_api/runtime/README.md
@@ -1,6 +1,6 @@
 # veda.stac_api
 
-## Enabling Multi-tenant STAC Backend
+## Enabling Multitenant STAC Backend
 
 To enable a multi-tenant STAC backend with transaction support and authentication, the following must be set:
 
@@ -23,7 +23,7 @@ To enable a multi-tenant STAC backend with transaction support and authenticatio
   - `stac:collection:create`, `stac:collection:update`, `stac:collection:delete`
   - `stac:item:create`, `stac:item:update`, `stac:item:delete`
 
-When multi-tenancy is enabled on a STAC catalog, a collection has the option to be added to a tenant in order to be filtered by that tenant value. This also means that a collection does not need to belong to any tenant. It will still be available and retrievable in the STAC catalog.
+When multitenancy is enabled on a STAC catalog, a collection has the option to be added to a tenant in order to be filtered by that tenant value. This also means that a collection does not need to belong to any tenant. It will still be available and retrievable in the STAC catalog.
 
 ### Migrating Existing Data to a Tenant Tagged Catalog
 
@@ -36,3 +36,22 @@ A [migration DAG ](https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dag
 **Field Format:**
 
 The `eic:tenant` field should contain a string identifier for the tenant.
+
+## Disabling Multitenancy
+
+Multi-tenancy is composed of two independent layers: **tenant-scoped filtering** and **PEP authorization**. Both require `VEDA_STAC_OPENID_CONFIGURATION_URL` to be set, but each has its own second toggle which can be enabled or disabled independently of each other.
+
+| Layer | What it does | Enabled when |
+| --- | --- | --- |
+| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`, adding `CollectionFilter` / `ItemFilter` and OIDC-protected write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` |
+| **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set |
+
+### Turning off each layer individually
+
+**To disable PEP authorization only** (keep tenant filtering if configured):
+
+- Unset `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME`. This prevents the Keycloak UMA `PEPMiddleware` from being added. Write endpoints will still require a valid OIDC token (enforced by `stac-auth-proxy`), but there will be no per-tenant resource permission checks.
+
+**To disable transaction (write) endpoints:**
+
+- Set `VEDA_STAC_ENABLE_TRANSACTIONS=False` (or leave unset). This is independent of both layers above and removes the POST/PUT/DELETE routes for collections and items.

--- a/stac_api/runtime/README.md
+++ b/stac_api/runtime/README.md
@@ -62,8 +62,8 @@ Multi-tenancy has several parts. The **two optional layers** below (auth-proxy f
 
 | Layer | What it does | Enabled when | Disabled when |
 | --- | --- | --- | --- |
-| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`: OpenID Connect, registers `CollectionFilter` / `ItemFilter` for tenant-aware list/search, OAuth-scoped write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` | `VEDA_STAC_OPENID_CONFIGURATION_URL` is not set **or** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=False` |
-| **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set | `VEDA_STAC_OPENID_CONFIGURATION_URL` is not set **or** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is not set |
+| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`: OpenID Connect, registers `CollectionFilter` / `ItemFilter` for tenant-aware list/search, OAuth-scoped write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` | `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=False` **or** UNSET |
+| **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set |  `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is not set |
 
 > **_NOTE:_**  `TenantExtractionMiddleware` and `TenantLinksMiddleware` (URL tenant prefix and JSON link rewriting) are **always** registered. They do not appear in this table because they are not toggled by these env vars; see [Middleware and multitenancy components](#middleware-and-multitenancy-components). When clients only use normal STAC paths (for example `/api/stac/collections` with no extra path segment), tenant extraction is a no-op.
 

--- a/stac_api/runtime/README.md
+++ b/stac_api/runtime/README.md
@@ -1,5 +1,24 @@
 # veda.stac_api
 
+## Middleware and multitenancy components
+
+Tenant-related behavior comes from **several middleware components**. Each row names one component, what it does, and how it is turned on (some are always on; others depend on environment variables).
+
+| Component | Role | Enabled when: |
+| --- | --- | --- |
+| **`TenantExtractionMiddleware`** | Parses tenant URLs such as `{root_path}/{tenant}/collections`, sets `request.state.tenant`, and rewrites `scope["path"]` so routing matches the usual STAC paths. | **Always** (see `app.py`). Independent of `VEDA_STAC_ENABLE_STAC_AUTH_PROXY`. |
+| **`TenantLinksMiddleware`** | For JSON STAC responses, rewrites `links` so clients stay on the tenant-prefixed URL when a tenant is present. | **Always** (see `app.py`). |
+| **`stac-auth-proxy` (`configure_app`)** | Wraps the STAC app: OpenAPI + OpenID Connect for clients, registers **`CollectionFilter` / `ItemFilter`** so list/search respect collection tenant metadata (`VEDA_TENANT_FILTER_FIELD`, default `eic:tenant`), and requires OAuth scopes on write routes. | When `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True`. |
+| **`PEPMiddleware`** | Keycloak UMA checks on configured write routes. | When `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set. |
+
+**How this fits together:**
+
+- **Tenant in the URL** (`/api/stac/veda/collections`, …) is handled by the **two URL-tenant middleware components** in the table so the core STAC app still sees `/api/stac/collections` while `request.state.tenant` is set. That works even when the auth proxy wrapper is **off**.
+- **Tenant in collection metadata** (filtering which collections/items appear for a tenant) is driven by the **filters registered through `stac-auth-proxy`** when the proxy is **on**. Turning the proxy off removes that integration; it does **not** remove URL parsing or link rewriting from the tenant middleware.
+- **Transactions** still require `VEDA_STAC_ENABLE_TRANSACTIONS=True` and, per configuration rules, `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` when transactions are enabled.
+
+Implementation reference: [`stac_api/runtime/src/app.py`](src/app.py) (conditional `configure_app`, optional PEP, then unconditional `TenantExtractionMiddleware` / `TenantLinksMiddleware`).
+
 ## Enabling Multitenant STAC Backend
 
 To enable a multi-tenant STAC backend with transaction support and authentication, the following must be set:
@@ -11,7 +30,7 @@ To enable a multi-tenant STAC backend with transaction support and authenticatio
 ### Required Environment Variables
 
 - `VEDA_STAC_ENABLE_TRANSACTIONS=True` - Enables STAC transaction endpoints (POST, PUT, DELETE)
-- `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` - Enables authentication middleware and custom tenant filtering
+- `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` - Wraps the app with `stac-auth-proxy` (OpenID Connect for clients, and registers `CollectionFilter` / `ItemFilter` so list/search endpoints respect collection tenant metadata and POST/PUT/PATCH/DELETE require OAuth scopes)
 - `VEDA_STAC_OPENID_CONFIGURATION_URL` - OIDC discovery endpoint URL
 - `VEDA_STAC_CLIENT_ID` - OAuth2 client ID for authentication
 
@@ -31,7 +50,7 @@ Existing collections in the STAC catalog need the `eic:tenant` field added to be
 
 **Migration Process:**
 
-A [migration DAG ](https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/veda_tenant_tagging_pipeline.py)is available in the [veda-data-airflow](https://github.com/NASA-IMPACT/veda-data-airflow) repository to add tenant fields to existing collections. The migration adds the `eic:tenant` field to collection metadata for the specified set of collections
+A [migration DAG](https://github.com/NASA-IMPACT/veda-data-airflow/blob/dev/dags/veda_data_pipeline/veda_tenant_tagging_pipeline.py) is available in the [veda-data-airflow](https://github.com/NASA-IMPACT/veda-data-airflow) repository to add tenant fields to existing collections. The migration adds the `eic:tenant` field to collection metadata for the specified set of collections
 
 **Field Format:**
 
@@ -39,12 +58,14 @@ The `eic:tenant` field should contain a string identifier for the tenant.
 
 ## Disabling Multitenancy
 
-Multi-tenancy is composed of two independent layers: **tenant-scoped filtering** and **PEP authorization**. Both require `VEDA_STAC_OPENID_CONFIGURATION_URL` to be set, but each has its own second toggle which can be enabled or disabled independently of each other.
+Multi-tenancy has several parts. The **two optional layers** below (auth-proxy filter integration and PEP) are toggled independently. Both require `VEDA_STAC_OPENID_CONFIGURATION_URL` to be set, plus each layer’s own second flag.
 
 | Layer | What it does | Enabled when |
 | --- | --- | --- |
-| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`, adding `CollectionFilter` / `ItemFilter` and OIDC-protected write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` |
+| **Tenant-scoped filtering** | Wraps the app with `stac-auth-proxy`: OpenID Connect, registers `CollectionFilter` / `ItemFilter` for tenant-aware list/search, OAuth-scoped write endpoints | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_STAC_ENABLE_STAC_AUTH_PROXY=True` |
 | **PEP authorization** | Adds Keycloak UMA middleware that checks per-tenant resource permissions on protected routes | `VEDA_STAC_OPENID_CONFIGURATION_URL` is set **and** `VEDA_KEYCLOAK_UMA_RESOURCE_SERVER_CLIENT_SECRET_NAME` is set |
+
+> **_NOTE:_**  `TenantExtractionMiddleware` and `TenantLinksMiddleware` (URL tenant prefix and JSON link rewriting) are **always** registered. They do not appear in this table because they are not toggled by these env vars; see [Middleware and multitenancy](#middleware-and-multitenancy). When clients only use normal STAC paths (for example `/api/stac/collections` with no extra path segment), tenant extraction is a no-op.
 
 ### Turning off each layer individually
 

--- a/stac_api/runtime/src/tenant_extraction_middleware.py
+++ b/stac_api/runtime/src/tenant_extraction_middleware.py
@@ -50,10 +50,14 @@ class TenantExtractionMiddleware:
         root_path = scope.get("root_path", "")
 
         original_path = scope["path"]
-        if original_path.endswith("/") and original_path not in [
-            "/",
-            root_path,
-        ]:
+        paths_keep_trailing_slash = {"/", root_path}
+        if root_path and not root_path.endswith("/"):
+            paths_keep_trailing_slash.add(f"{root_path}/")
+
+        if (
+            original_path.endswith("/")
+            and original_path not in paths_keep_trailing_slash
+        ):
             logger.debug(f"{original_path=}")
             scope["path"] = original_path.rstrip("/")
             logger.debug(f"Removed trailing slash so now path is {scope['path']}")

--- a/stac_api/runtime/tests/test_tenant_extraction_middleware.py
+++ b/stac_api/runtime/tests/test_tenant_extraction_middleware.py
@@ -1,0 +1,92 @@
+"""Unit tests for TenantExtractionMiddleware"""
+
+from typing import Any
+
+from src.tenant_extraction_middleware import TenantExtractionMiddleware
+
+from fastapi import FastAPI, Request
+from starlette.testclient import TestClient
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+def _inject_root_path(app: ASGIApp, root_path: str) -> ASGIApp:
+    """Add root_path to each HTTP scope."""
+
+    async def asgi(scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            scope = {**scope, "root_path": root_path}
+        await app(scope, receive, send)
+
+    return asgi
+
+
+def _request_after_middleware(request: Request) -> dict[str, Any]:
+    """Used for JSON assertions"""
+    return {
+        "scope_path": request.scope["path"],
+        "root_path": request.scope.get("root_path", ""),
+        "tenant": getattr(request.state, "tenant", None),
+    }
+
+
+def _stac_client_with_root_path(root_path: str) -> TestClient:
+    """Client with middleware"""
+    app = FastAPI()
+    app.add_middleware(TenantExtractionMiddleware)
+
+    @app.get("/")
+    async def stac_root(request: Request):
+        return _request_after_middleware(request)
+
+    @app.get("/collections")
+    async def stac_collections(request: Request):
+        return _request_after_middleware(request)
+
+    wrapped = _inject_root_path(app, root_path)
+    return TestClient(wrapped)
+
+
+def test_preserves_trailing_slash_on_stac_root():
+    client = _stac_client_with_root_path("/api/stac")
+    response = client.get("/api/stac/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope_path"] == "/api/stac/"
+    assert data["root_path"] == "/api/stac"
+    assert data["tenant"] is None
+
+
+def test_strips_trailing_slash_on_nested_path():
+    client = _stac_client_with_root_path("/api/stac")
+    response = client.get("/api/stac/collections/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope_path"] == "/api/stac/collections"
+    assert data["tenant"] is None
+
+
+def test_strips_trailing_slash_when_root_path_empty():
+    """First path segment must be a standard endpoint so no tenant is extracted"""
+    app = FastAPI()
+    app.add_middleware(TenantExtractionMiddleware)
+
+    @app.get("/collections/items")
+    async def items(request: Request):
+        return _request_after_middleware(request)
+
+    client = TestClient(app)
+    response = client.get("/collections/items/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope_path"] == "/collections/items"
+    assert data["root_path"] == ""
+    assert data["tenant"] is None
+
+
+def test_extracts_tenant_and_rewrites_path_for_tenant_collections():
+    client = _stac_client_with_root_path("/api/stac")
+    response = client.get("/api/stac/veda/collections/")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scope_path"] == "/api/stac/collections"
+    assert data["tenant"] == "veda"

--- a/stac_api/runtime/tests/test_tenant_extraction_middleware.py
+++ b/stac_api/runtime/tests/test_tenant_extraction_middleware.py
@@ -47,6 +47,7 @@ def _stac_client_with_root_path(root_path: str) -> TestClient:
 
 
 def test_preserves_trailing_slash_on_stac_root():
+    """Keep root_path/ unchanged"""
     client = _stac_client_with_root_path("/api/stac")
     response = client.get("/api/stac/")
     assert response.status_code == 200
@@ -57,6 +58,7 @@ def test_preserves_trailing_slash_on_stac_root():
 
 
 def test_strips_trailing_slash_on_nested_path():
+    """Normalize trailing slash on non-root paths under root_path"""
     client = _stac_client_with_root_path("/api/stac")
     response = client.get("/api/stac/collections/")
     assert response.status_code == 200
@@ -84,6 +86,7 @@ def test_strips_trailing_slash_when_root_path_empty():
 
 
 def test_extracts_tenant_and_rewrites_path_for_tenant_collections():
+    """Strip tenant segment from path and set request.state.tenant"""
     client = _stac_client_with_root_path("/api/stac")
     response = client.get("/api/stac/veda/collections/")
     assert response.status_code == 200


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/596
https://github.com/NASA-IMPACT/veda-architecture/issues/754

### What?

- Updates the docs to include more information about disabling multitenancy features, distinguishing between filtering and authorization
- Updates TenantExtractionMiddleware logic for root paths with trailing slash (so it skips trailing slash removal for `{root_path}/`)
- Adds unit tests for TenantExtractionMiddleware

Tested tenant extraction change in UAH-SIT.
| Test setup | Result |
| --|--|
| Envs: STAC_AUTH_PROXY_ENABLED=False, used v14.0.0-rc.16 | redirect errors on https://sit.openveda.cloud/api/stac/ |
| Envs: STAC_AUTH_PROXY_ENABLED=False, used this branch's commit SHA | redirect errors resolved on https://sit.openveda.cloud/api/stac/| 

The reason we didn't notice this before is because we never had an instance tested where we had the Tenant Extraction middleware running while Tenant Filtering (AKA stac-auth-proxy) was disabled. 