### PR TITLE
chore(ci): create releases on develop branch and deprecate release candidate strategy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
     - develop
-    - main
 
 jobs:
     release:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,9 @@ logging_use_named_masks = false
 major_on_zero = true
 tag_format = "v{version}"
 
-[tool.semantic_release.branches.main]
-match = "(main|master)"
-prerelease_token = "rc"
-prerelease = false
-
 [tool.semantic_release.branches.develop]
 match = "develop"
-prerelease = true
-prerelease_token = "rc"
+prerelease = false
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "style", "refactor", "test"]


### PR DESCRIPTION
We want to consolidate our semantic release strategy to a single branch (develop) because we no longer have a production CICD pipeline configured for the main branch.

