### PR TITLE
fix: cdk deploy actions shas

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -32,7 +32,7 @@ runs:
           ${{ inputs.dir }}/setup.cfg
 
     - name: Setup Node
-      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e4 #v4.3.0
+      uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 22
 


### PR DESCRIPTION
Commit `cdca7365b2dadb8aad0a33bc7601856ffabcc48e4` doesn't exist, we should use https://github.com/actions/setup-node/commit/cdca7365b2dadb8aad0a33bc7601856ffabcc48e