### PR TITLE
ci: security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    cooldown:
+      default-days: 7
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns:
+        - "*"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,15 +15,6 @@ updates:
     commit-message:
       prefix: "chore(deps):"
 
-  - package-ecosystem: "docker"
-    directory: "/"
-    cooldown:
-      default-days: 7
-    schedule:
-      interval: weekly
-    commit-message:
-      prefix: "chore(deps):"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     cooldown:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,7 +1,6 @@
 name: CDK Deploy Dev Workflow 🚀
 
 permissions:
-  id-token: write
   contents: read
 
 on:
@@ -34,6 +33,8 @@ jobs:
     needs: [define-environment]
     environment: ${{ needs.define-environment.outputs.env_name }}
     concurrency: ${{ needs.define-environment.outputs.env_name }}
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release Workflow
 
 permissions:
-  id-token: write
   contents: read
 
 on:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: OSSF Scorecard
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "30 16 * * 1" # Monday 10:30/11:30 CT
+
+permissions: read-all # Default all to readonly
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Allow upload to Security dashboard
+      id-token: write # Access GitHub's OIDC token to verify authenticity of result for publish
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
>[!NOTE]
>See https://github.com/NASA-IMPACT/veda-keycloak/pull/253 for more detail on OSSF Scorecard + Dependabot configs, removed repeated detail to help reviewers and better highlight repo-specific deltas.

---

- Dependabot version updates added:
    - `pip` (CDK build, service dependencies)
    - `docker` (service container images)
    - `github-actions` (CI)
- [OSSF Scorecard](https://github.com/ossf/scorecard-action) added
- Token permissions
    - Move write permissions from top-level (all jobs) to specific job required