### PR TITLE
fix(raster): de-duplicate vendored PROJ database

### DIFF
--- a/raster_api/infrastructure/construct.py
+++ b/raster_api/infrastructure/construct.py
@@ -54,6 +54,9 @@ class RasterApiLambdaConstruct(Construct):
             log_retention=aws_logs.RetentionDays.ONE_WEEK,
             environment={
                 **veda_raster_settings.env,
+                # pyproj's vendored PROJ database is dropped at build time to save
+                # ~9MB; point it at rasterio's. See raster_api/runtime/Dockerfile.
+                "PROJ_DATA": "/var/task/rasterio/proj_data",
                 "VEDA_RASTER_ENABLE_MOSAIC_SEARCH": str(
                     veda_raster_settings.raster_enable_mosaic_search
                 ),

--- a/raster_api/runtime/Dockerfile
+++ b/raster_api/runtime/Dockerfile
@@ -16,6 +16,12 @@ RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 
+# rasterio and pyproj each vendor a ~9.5MB PROJ database; keep only rasterio's.
+# Must keep the newer one - GDAL rejects an older DATABASE.LAYOUT.VERSION.
+# PROJ_DATA here is for the build check below; runtime gets it from construct.py.
+RUN rm -f /asset/pyproj/proj_dir/share/proj/proj.db
+ENV PROJ_DATA=/asset/rasterio/proj_data
+
 COPY raster_api/runtime/handler.py /asset/handler.py
 RUN dnf remove -y gcc-c++
 


### PR DESCRIPTION
Slack convo: https://developmentseed.slack.com/archives/C045K5LAFA9/p1786567144333719

Our raster API image is too big! This trims 9-10MB, giving us 7MB of headroom. I don't think this breaks anything - `proj` gets pointed to the DB from `rasterio`, which is newer and likely better.