### PR TITLE
fix: only set rds storage encryption if its enabled

### DIFF
--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -223,9 +223,11 @@ class RdsConstruct(Construct):
 
         # Or create/update RDS Resource
         else:
+            if veda_db_settings.rds_encryption:
+                database_config["storage_encrypted"] = True
+
             database = aws_rds.DatabaseInstance(
                 self,
-                storage_encrypted=veda_db_settings.rds_encryption or False,
                 **database_config,
             )
 

--- a/database/infrastructure/construct.py
+++ b/database/infrastructure/construct.py
@@ -224,12 +224,16 @@ class RdsConstruct(Construct):
         # Or create/update RDS Resource
         else:
             if veda_db_settings.rds_encryption:
-                database_config["storage_encrypted"] = True
-
-            database = aws_rds.DatabaseInstance(
-                self,
-                **database_config,
-            )
+                database = aws_rds.DatabaseInstance(
+                    self,
+                    **database_config,
+                    storage_encrypted=True,
+                )
+            else:
+                database = aws_rds.DatabaseInstance(
+                    self,
+                    **database_config,
+                )
 
         hostname = database.instance_endpoint.hostname
         self.db_security_group = database.connections.security_groups[0]


### PR DESCRIPTION
### Issue

https://github.com/NASA-IMPACT/veda-backend/issues/637

### What?

- Avoids setting storage_encrypted property on an RDS if it is not already defined 

### Why?

> _If you're adding or removing a property that requires a replacement, it will also trigger an update. The update will happen even if the real value of the property doesn't change._

https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-rds-dbinstance.html#:~:text=Type%3A%20Boolean-,Update%20requires%3A%20Replacement,-StorageThroughput

https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#:~:text=If%20you%27re%20adding%20or%20removing%20a%20property%20that%20requires%20a%20replacement%2C%20it%20will%20also%20trigger%20an%20update.%20The%20update%20will%20happen%20even%20if%20the%20real%20value%20of%20the%20property%20doesn%27t%20change

### Testing?

- CDK diff against a stack w/o storage_encrypted previously defined does not cause `Update requires: Replacement` 

