### PR TITLE
fix: use oidc role for pr workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -45,7 +45,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
           role-session-name: "veda-backend-github-${{ needs.define-environment.outputs.env_name }}-deployment"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,7 +107,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
-          role-session-name: "veda-backend-predeploy-${{ github.ref_name }}"
+          role-session-name: "veda-backend-predeploy-${{ github.event.pull_request.number }}"
           aws-region: 'us-west-2'
 
       - name: Install python dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,10 +35,15 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Configure awscli
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "veda-backend-test-${{ github.event.pull_request.number }}"
+          aws-region: 'us-west-2'
+
       - name: Launch services
         run: |
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}}
           docker compose up --build -d
 
       - name: Set up uv

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,10 @@ jobs:
   test:
     needs: [lint, lint-conventional-pr]
     runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,10 +92,9 @@ jobs:
 
   predeploy:
     needs: [test]
-
     runs-on: ubuntu-latest
+    environment: dev
     steps:
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up uv

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,11 +104,11 @@ jobs:
           enable-cache: true
 
       - name: Configure awscli
-        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-2
+          role-to-assume: ${{ secrets.DEPLOYMENT_ROLE_ARN }}
+          role-session-name: "veda-backend-predeploy-${{ github.ref_name }}"
+          aws-region: 'us-west-2'
 
       - name: Install python dependencies
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -94,6 +94,9 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     environment: dev
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
### Issue

- https://github.com/NASA-IMPACT/veda-architecture/issues/853

### What?

- Changes the pr workflow to use the deployment role rather than aws secret access id

### Why?

- details in issue

### Testing?

- PR workflow passes

